### PR TITLE
feat: adopt sketch-core runtime modules into existing sketches/ layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "serde-big-array",
  "smallvec",
  "twox-hash",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -641,6 +642,12 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ twox-hash = "2.1.2"
 smallvec = "1.13.2"
 prost = "0.13"
 bytes = "1"
+xxhash-rust = { version = "0.8", features = ["xxh32"] }
 core_affinity = { version = "0.8", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 

--- a/src/sketches/cms_heap.rs
+++ b/src/sketches/cms_heap.rs
@@ -878,3 +878,481 @@ mod tests {
         );
     }
 }
+
+// =====================================================================
+// asap_sketchlib wire-format-aligned variant.
+//
+// `CountMinSketchWithHeap` and `CmsHeapItem` below are the
+// public-field, proto-decode-friendly types consumed by the ASAP query
+// engine accumulators, backed by `asap_sketchlib`'s in-tree CMSHeap.
+// All hashing is delegated to the `SketchlibCMSHeap` backend (which
+// uses `DefaultXxHasher`), so producer and consumer always agree on
+// bucket assignments. The high-throughput in-process variant above
+// (`CMSHeap`) keeps its original design. Note: the wire-format
+// heap-item type was renamed `HeapItem` -> `CmsHeapItem` to avoid
+// collision with `common::input::HeapItem` (the polymorphic key type
+// used by the generic in-process heap).
+// =====================================================================
+
+use serde::{Deserialize, Serialize};
+
+// ----- asap_sketchlib-backed CMSHeap helpers -----
+// Used below by `CountMinSketchWithHeap`. Lives in this file so the
+// wire-format type and its backend share a single home.
+
+/// Wire-format heap item (key, value) used by the dispatch helpers below.
+pub struct WireHeapItem {
+    pub key: String,
+    pub value: f64,
+}
+
+/// Concrete Count-Min-with-Heap type backing the wire-format `CountMinSketchWithHeap`.
+pub type SketchlibCMSHeap = CMSHeap<Vector2D<i64>, RegularPath>;
+
+/// Creates a fresh CMSHeap with the given dimensions and heap capacity.
+pub fn new_sketchlib_cms_heap(
+    row_num: usize,
+    col_num: usize,
+    heap_size: usize,
+) -> SketchlibCMSHeap {
+    CMSHeap::new(row_num, col_num, heap_size)
+}
+
+/// Builds a CMSHeap from an existing sketch matrix and optional heap items.
+/// Used when deserializing wire-format state.
+pub fn sketchlib_cms_heap_from_matrix_and_heap(
+    row_num: usize,
+    col_num: usize,
+    heap_size: usize,
+    sketch: &[Vec<f64>],
+    topk_heap: &[WireHeapItem],
+) -> SketchlibCMSHeap {
+    let matrix = Vector2D::from_fn(row_num, col_num, |r, c| {
+        sketch
+            .get(r)
+            .and_then(|row| row.get(c))
+            .copied()
+            .unwrap_or(0.0)
+            .round() as i64
+    });
+    let mut cms_heap = CMSHeap::from_storage(matrix, heap_size);
+
+    // Populate the heap from wire-format topk_heap
+    for item in topk_heap {
+        let count = item.value.round() as i64;
+        if count > 0 {
+            let input = DataInput::Str(&item.key);
+            cms_heap.heap_mut().update(&input, count);
+        }
+    }
+
+    cms_heap
+}
+
+/// Converts a CMSHeap's storage into a `Vec<Vec<f64>>` matrix.
+pub fn matrix_from_sketchlib_cms_heap(cms_heap: &SketchlibCMSHeap) -> Vec<Vec<f64>> {
+    let storage = cms_heap.cms().as_storage();
+    let rows = storage.rows();
+    let cols = storage.cols();
+    let mut sketch = vec![vec![0.0; cols]; rows];
+
+    for (r, row) in sketch.iter_mut().enumerate().take(rows) {
+        for (c, cell) in row.iter_mut().enumerate().take(cols) {
+            if let Some(v) = storage.get(r, c) {
+                *cell = *v as f64;
+            }
+        }
+    }
+
+    sketch
+}
+
+/// Converts sketchlib HHHeap items to wire-format (key, value) pairs.
+pub fn heap_to_wire(cms_heap: &SketchlibCMSHeap) -> Vec<WireHeapItem> {
+    cms_heap
+        .heap()
+        .heap()
+        .iter()
+        .map(|hh_item| {
+            let key = match &hh_item.key {
+                crate::HeapItem::String(s) => s.clone(),
+                other => format!("{:?}", other),
+            };
+            WireHeapItem {
+                key,
+                value: hh_item.count as f64,
+            }
+        })
+        .collect()
+}
+
+/// Updates a CMSHeap with a weighted key. Automatically updates the heap.
+pub fn sketchlib_cms_heap_update(cms_heap: &mut SketchlibCMSHeap, key: &str, value: f64) {
+    let many = value.round() as i64;
+    if many <= 0 {
+        return;
+    }
+    let input = DataInput::String(key.to_owned());
+    cms_heap.insert_many(&input, many);
+}
+
+/// Queries a CMSHeap for a key's frequency estimate.
+pub fn sketchlib_cms_heap_query(cms_heap: &SketchlibCMSHeap, key: &str) -> f64 {
+    let input = DataInput::String(key.to_owned());
+    cms_heap.estimate(&input) as f64
+}
+
+/// Item in the top-k heap representing a key-value pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CmsHeapItem {
+    pub key: String,
+    pub value: f64,
+}
+
+/// Helper struct matching the nested wire serialization format (inner CMS).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CmsData {
+    sketch: Vec<Vec<f64>>,
+    #[serde(rename = "row_num")]
+    rows: usize,
+    #[serde(rename = "col_num")]
+    cols: usize,
+}
+
+/// Helper struct matching the wire serialization format (outer wrapper).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CountMinSketchWithHeapSerialized {
+    sketch: CmsData,
+    topk_heap: Vec<CmsHeapItem>,
+    heap_size: usize,
+}
+
+/// Count-Min Sketch with Heap for top-k tracking.
+/// Combines probabilistic frequency counting with efficient top-k maintenance.
+pub struct CountMinSketchWithHeap {
+    pub rows: usize,
+    pub cols: usize,
+    pub heap_size: usize,
+    pub(crate) backend: SketchlibCMSHeap,
+}
+
+impl std::fmt::Debug for CountMinSketchWithHeap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CountMinSketchWithHeap")
+            .field("rows", &self.rows)
+            .field("cols", &self.cols)
+            .field("heap_size", &self.heap_size)
+            .finish()
+    }
+}
+
+impl Clone for CountMinSketchWithHeap {
+    fn clone(&self) -> Self {
+        let sketch = matrix_from_sketchlib_cms_heap(&self.backend);
+        let wire_heap: Vec<WireHeapItem> = heap_to_wire(&self.backend);
+        Self {
+            rows: self.rows,
+            cols: self.cols,
+            heap_size: self.heap_size,
+            backend: sketchlib_cms_heap_from_matrix_and_heap(
+                self.rows,
+                self.cols,
+                self.heap_size,
+                &sketch,
+                &wire_heap,
+            ),
+        }
+    }
+}
+
+impl CountMinSketchWithHeap {
+    pub fn new(rows: usize, cols: usize, heap_size: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            heap_size,
+            backend: new_sketchlib_cms_heap(rows, cols, heap_size),
+        }
+    }
+
+    /// Number of hash rows in the sketch matrix.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns (width) in the sketch matrix.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Create from a sketch matrix and heap (e.g. from JSON deserialization).
+    pub fn from_legacy_matrix(
+        sketch: Vec<Vec<f64>>,
+        topk_heap: Vec<CmsHeapItem>,
+        rows: usize,
+        cols: usize,
+        heap_size: usize,
+    ) -> Self {
+        let wire_heap: Vec<WireHeapItem> = topk_heap
+            .into_iter()
+            .map(|h| WireHeapItem {
+                key: h.key,
+                value: h.value,
+            })
+            .collect();
+        Self {
+            rows,
+            cols,
+            heap_size,
+            backend: sketchlib_cms_heap_from_matrix_and_heap(
+                rows, cols, heap_size, &sketch, &wire_heap,
+            ),
+        }
+    }
+
+    /// Get the top-k heap items.
+    pub fn topk_heap_items(&self) -> Vec<CmsHeapItem> {
+        heap_to_wire(&self.backend)
+            .into_iter()
+            .map(|w| CmsHeapItem {
+                key: w.key,
+                value: w.value,
+            })
+            .collect()
+    }
+
+    /// Get the sketch matrix.
+    pub fn sketch_matrix(&self) -> Vec<Vec<f64>> {
+        matrix_from_sketchlib_cms_heap(&self.backend)
+    }
+
+    pub fn update(&mut self, key: &str, value: f64) {
+        sketchlib_cms_heap_update(&mut self.backend, key, value);
+    }
+
+    /// Estimate the frequency of `key` (CountMin point query).
+    pub fn estimate(&self, key: &str) -> f64 {
+        sketchlib_cms_heap_query(&self.backend, key)
+    }
+
+    /// Merge another CountMinSketchWithHeap into self in place. Both
+    /// operands must have identical dimensions; the resulting heap_size
+    /// is the minimum of the two.
+    pub fn merge(
+        &mut self,
+        other: &CountMinSketchWithHeap,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != other.rows || self.cols != other.cols {
+            return Err(format!(
+                "CountMinSketchWithHeap dimension mismatch: self={}x{}, other={}x{}",
+                self.rows, self.cols, other.rows, other.cols
+            )
+            .into());
+        }
+        self.backend.merge(&other.backend);
+        self.heap_size = self.heap_size.min(other.heap_size);
+        Ok(())
+    }
+
+    /// Merge from references, returning a new sketch — convenience
+    /// for batch reduction at API edges. The resulting heap_size is
+    /// the minimum across all inputs.
+    pub fn merge_refs(
+        inputs: &[&CountMinSketchWithHeap],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let first = inputs
+            .first()
+            .ok_or("CountMinSketchWithHeap::merge_refs called with empty input")?;
+        let mut merged = (*first).clone();
+        for h in inputs.iter().skip(1) {
+            merged.merge(h)?;
+        }
+        Ok(merged)
+    }
+
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        let (sketch, topk_heap) = (self.sketch_matrix(), self.topk_heap_items());
+
+        let serialized = CountMinSketchWithHeapSerialized {
+            sketch: CmsData {
+                sketch,
+                rows: self.rows,
+                cols: self.cols,
+            },
+            topk_heap,
+            heap_size: self.heap_size,
+        };
+
+        let mut buf = Vec::new();
+        serialized.serialize(&mut rmp_serde::Serializer::new(&mut buf))?;
+        Ok(buf)
+    }
+
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let serialized: CountMinSketchWithHeapSerialized = rmp_serde::from_slice(buffer).map_err(
+            |e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to deserialize CountMinSketchWithHeap from MessagePack: {e}").into()
+            },
+        )?;
+
+        let mut sorted_topk_heap = serialized.topk_heap;
+        sorted_topk_heap.sort_by(|a, b| b.value.partial_cmp(&a.value).unwrap());
+
+        let wire_heap: Vec<WireHeapItem> = sorted_topk_heap
+            .iter()
+            .map(|h| WireHeapItem {
+                key: h.key.clone(),
+                value: h.value,
+            })
+            .collect();
+        let backend = sketchlib_cms_heap_from_matrix_and_heap(
+            serialized.sketch.rows,
+            serialized.sketch.cols,
+            serialized.heap_size,
+            &serialized.sketch.sketch,
+            &wire_heap,
+        );
+
+        Ok(Self {
+            rows: serialized.sketch.rows,
+            cols: serialized.sketch.cols,
+            heap_size: serialized.heap_size,
+            backend,
+        })
+    }
+
+    pub fn aggregate_topk(
+        rows: usize,
+        cols: usize,
+        heap_size: usize,
+        keys: &[&str],
+        values: &[f64],
+    ) -> Option<Vec<u8>> {
+        if keys.is_empty() {
+            return None;
+        }
+        let mut sketch = Self::new(rows, cols, heap_size);
+        for (key, &value) in keys.iter().zip(values.iter()) {
+            sketch.update(key, value);
+        }
+        sketch.serialize_msgpack().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests_wire_cms_heap {
+    use super::*;
+
+    #[test]
+    fn test_creation() {
+        let cms = CountMinSketchWithHeap::new(4, 1000, 20);
+        assert_eq!(cms.rows, 4);
+        assert_eq!(cms.cols, 1000);
+        assert_eq!(cms.heap_size, 20);
+        assert_eq!(cms.sketch_matrix().len(), 4);
+        assert_eq!(cms.sketch_matrix()[0].len(), 1000);
+        assert_eq!(cms.topk_heap_items().len(), 0);
+    }
+
+    #[test]
+    fn test_query_empty() {
+        let cms = CountMinSketchWithHeap::new(2, 10, 5);
+        assert_eq!(cms.estimate("anything"), 0.0);
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut sketch1 = vec![vec![0.0; 10]; 2];
+        sketch1[0][0] = 10.0;
+        sketch1[1][1] = 20.0;
+        let mut cms1 = CountMinSketchWithHeap::from_legacy_matrix(
+            sketch1,
+            vec![
+                CmsHeapItem {
+                    key: "key1".to_string(),
+                    value: 100.0,
+                },
+                CmsHeapItem {
+                    key: "key2".to_string(),
+                    value: 50.0,
+                },
+            ],
+            2,
+            10,
+            5,
+        );
+        let mut sketch2 = vec![vec![0.0; 10]; 2];
+        sketch2[0][0] = 5.0;
+        sketch2[1][1] = 15.0;
+        let cms2 = CountMinSketchWithHeap::from_legacy_matrix(
+            sketch2,
+            vec![
+                CmsHeapItem {
+                    key: "key3".to_string(),
+                    value: 75.0,
+                },
+                CmsHeapItem {
+                    key: "key1".to_string(),
+                    value: 80.0,
+                },
+            ],
+            2,
+            10,
+            3,
+        );
+
+        cms1.merge(&cms2).unwrap();
+
+        assert_eq!(cms1.sketch_matrix()[0][0], 15.0);
+        assert_eq!(cms1.sketch_matrix()[1][1], 35.0);
+        assert_eq!(cms1.heap_size, 3);
+        assert!(cms1.topk_heap_items().len() <= 3);
+    }
+
+    #[test]
+    fn test_merge_dimension_mismatch() {
+        let mut cms1 = CountMinSketchWithHeap::new(2, 10, 5);
+        let cms2 = CountMinSketchWithHeap::new(3, 10, 5);
+        assert!(cms1.merge(&cms2).is_err());
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let mut cms = CountMinSketchWithHeap::new(4, 128, 3);
+        cms.update("hot", 100.0);
+        cms.update("cold", 1.0);
+
+        let bytes = cms.serialize_msgpack().unwrap();
+        let deserialized = CountMinSketchWithHeap::deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(deserialized.rows, 4);
+        assert_eq!(deserialized.cols, 128);
+        assert_eq!(deserialized.heap_size, 3);
+        let items = deserialized.topk_heap_items();
+        assert!(!items.is_empty());
+        let hot = items
+            .iter()
+            .find(|item| item.key == "hot")
+            .expect("'hot' should be in the heap");
+        assert!(hot.value >= 100.0);
+        assert!(deserialized.estimate("hot") >= 100.0);
+        assert!(deserialized.estimate("cold") >= 1.0);
+    }
+
+    #[test]
+    fn test_aggregate_topk() {
+        let keys = ["a", "b", "a", "c"];
+        let values = [1.0, 2.0, 3.0, 0.5];
+        let bytes = CountMinSketchWithHeap::aggregate_topk(4, 100, 2, &keys, &values).unwrap();
+        let cms = CountMinSketchWithHeap::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(cms.heap_size, 2);
+        assert!(cms.topk_heap_items().len() <= 2);
+    }
+
+    #[test]
+    fn test_aggregate_topk_empty() {
+        assert!(CountMinSketchWithHeap::aggregate_topk(4, 100, 10, &[], &[]).is_none());
+    }
+}

--- a/src/sketches/count.rs
+++ b/src/sketches/count.rs
@@ -1378,3 +1378,326 @@ mod tests {
         );
     }
 }
+
+// =====================================================================
+// ASAP runtime wire-format-aligned variant .
+//
+// `CountSketch` and `CountSketchDelta` below are the public-field,
+// proto-decode-friendly types consumed by the ASAP query engine
+// accumulators. The high-throughput in-process variant above
+// (`Count`) keeps its original design.
+// =====================================================================
+
+// Count Sketch (a.k.a. Count-Min-style signed-counter sketch) —
+// element-wise mergeable frequency estimator.
+//
+// Parallel to `count_min::CountMinSketch` but with **signed** counters,
+// matching the `asap_sketchlib::proto::sketchlib::CountSketchState` wire
+// format that DataCollector's `countsketchprocessor` emits via the
+// modified OTLP `Metric.data = CountSketch{…}` variant.
+//
+// This is the minimal surface needed for PR C-CountSketch in the
+// modified-OTLP hot path: construct from a decoded proto state, merge
+// element-wise with another sketch, emit the matrix for queries and
+// serialization. The richer query semantics of Count Sketch (median-
+// of-estimators heavy-hitter tracking, `TopKState` integration, etc.)
+// are intentionally deferred to a follow-up — the wire format already
+// carries the matrix losslessly, so the merge/store round-trip works
+// with just a matrix today.
+
+// (de-duplicated) use serde::{Deserialize, Serialize};
+
+/// Sparse delta between two consecutive CountSketch snapshots —
+/// the input shape for [`CountSketch::apply_delta`]. Mirrors the
+/// `CountSketchDelta` proto in
+/// `sketchlib-go/proto/countsketch/countsketch.proto` (packed
+/// encoding only — the deprecated `cells_legacy` path + the
+/// non-delta `topk` / `hh_keys` top-K carrier aren't modeled here).
+///
+/// Cells apply additively: `matrix[row][col] += d_count` for each
+/// `(row, col, d_count)` triple. Top-K on the delta path is a
+/// separate follow-up (CS top-K is non-linear; merging deltas
+/// would require re-querying the merged matrix).
+#[derive(Debug, Clone, Default)]
+pub struct CountSketchDelta {
+    pub rows: u32,
+    pub cols: u32,
+    /// `(row, col, d_count)` cell updates, additive on the CS matrix.
+    pub cells: Vec<(u32, u32, i64)>,
+    /// Per-row L2 norm deltas. Additive, one scalar per row of the
+    /// base sketch. Kept on the delta surface for downstream
+    /// error-accounting; `apply_delta` itself ignores L2.
+    pub l2: Vec<f64>,
+}
+
+/// Minimal Count Sketch state — a flat `rows × cols` matrix of signed
+/// counts. Element-wise mergeable (sum over aligned cells).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CountSketch {
+    #[serde(rename = "row_num")]
+    pub rows: usize,
+    #[serde(rename = "col_num")]
+    pub cols: usize,
+    /// Row-major matrix of signed counts. `matrix[r][c]` is the value of
+    /// hash row `r`, column `c`.
+    pub matrix: Vec<Vec<f64>>,
+}
+
+impl CountSketch {
+    /// Construct an all-zero sketch with the given dimensions.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            matrix: vec![vec![0.0; cols]; rows],
+        }
+    }
+
+    /// Construct from a pre-built matrix (used by the modified-OTLP
+    /// proto-decode path).
+    pub fn from_legacy_matrix(matrix: Vec<Vec<f64>>, rows: usize, cols: usize) -> Self {
+        debug_assert_eq!(matrix.len(), rows, "row count mismatch");
+        debug_assert!(
+            matrix.iter().all(|r| r.len() == cols),
+            "column count mismatch in at least one row"
+        );
+        Self { rows, cols, matrix }
+    }
+
+    /// Borrow the inner matrix.
+    pub fn sketch(&self) -> &Vec<Vec<f64>> {
+        &self.matrix
+    }
+
+    /// Insert a single weighted observation. Each row uses an independent
+    /// hash seed and a sign bit to update the matrix in place — the
+    /// standard CountSketch update primitive. The wire format here uses
+    /// xxh64 with per-row seeding; this matches sketchlib-go's
+    /// `DeriveIndex`/`DeriveSign` decomposition for matrix-backed
+    /// sketches and is intended for in-process tests / ground-truth
+    /// builds, not cross-language replay.
+    pub fn update(&mut self, key: &str, value: f64) {
+        if self.rows == 0 || self.cols == 0 {
+            return;
+        }
+        let key_bytes = key.as_bytes();
+        for r in 0..self.rows {
+            let h = twox_hash::XxHash64::oneshot(r as u64, key_bytes);
+            let col = (h as usize) % self.cols;
+            // Sign derived from the high bit, matching the in-process
+            // Count Sketch implementation above.
+            let sign = if (h >> 63) & 1 == 1 { 1.0 } else { -1.0 };
+            self.matrix[r][col] += sign * value;
+        }
+    }
+
+    /// Estimate the frequency of `key` via the standard median-of-rows
+    /// CountSketch query. Returns 0 for an empty sketch.
+    pub fn estimate(&self, key: &str) -> f64 {
+        if self.rows == 0 || self.cols == 0 {
+            return 0.0;
+        }
+        let key_bytes = key.as_bytes();
+        let mut estimates: Vec<f64> = Vec::with_capacity(self.rows);
+        for r in 0..self.rows {
+            let h = twox_hash::XxHash64::oneshot(r as u64, key_bytes);
+            let col = (h as usize) % self.cols;
+            let sign = if (h >> 63) & 1 == 1 { 1.0 } else { -1.0 };
+            estimates.push(sign * self.matrix[r][col]);
+        }
+        estimates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mid = estimates.len() / 2;
+        if estimates.len() % 2 == 1 {
+            estimates[mid]
+        } else {
+            (estimates[mid - 1] + estimates[mid]) / 2.0
+        }
+    }
+
+    /// Merge one other sketch into self via element-wise addition. Both
+    /// operands must have identical dimensions.
+    pub fn merge(
+        &mut self,
+        other: &CountSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != other.rows || self.cols != other.cols {
+            return Err(format!(
+                "CountSketch dimension mismatch: self={}x{}, other={}x{}",
+                self.rows, self.cols, other.rows, other.cols
+            )
+            .into());
+        }
+        for r in 0..self.rows {
+            for c in 0..self.cols {
+                self.matrix[r][c] += other.matrix[r][c];
+            }
+        }
+        Ok(())
+    }
+
+    /// Apply a sparse delta in place. Matches the `ApplyDelta`
+    /// semantics in `sketchlib-go/sketches/CountSketch/delta.go`:
+    /// `matrix[row][col] += d_count` for each cell in the delta.
+    /// Returns `Err` if any `(row, col)` is out of range — indicating
+    /// a dimension mismatch between the snapshot this sketch was
+    /// built from and the delta sender.
+    pub fn apply_delta(
+        &mut self,
+        delta: &CountSketchDelta,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for (row, col, d_count) in &delta.cells {
+            let r = *row as usize;
+            let c = *col as usize;
+            if r >= self.rows || c >= self.cols {
+                return Err(format!(
+                    "CountSketchDelta cell ({r},{c}) out of range (matrix={}x{})",
+                    self.rows, self.cols
+                )
+                .into());
+            }
+            // `d_count` is signed on the wire; CS counts are signed
+            // too (can go negative under adversarial keys).
+            self.matrix[r][c] += *d_count as f64;
+        }
+        Ok(())
+    }
+
+    /// Merge a slice of references into a single new sketch. All inputs
+    /// must share the same dimensions; returns `Err` on mismatch or an
+    /// empty input.
+    pub fn merge_refs(
+        inputs: &[&CountSketch],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let first = inputs
+            .first()
+            .ok_or("CountSketch::merge_refs called with empty input")?;
+        let mut merged = CountSketch::new(first.rows, first.cols);
+        for cs in inputs {
+            merged.merge(cs)?;
+        }
+        Ok(merged)
+    }
+
+    /// Serialize to MessagePack bytes (used by the legacy wire path
+    /// and by PR I's `_ENCODING_MSGPACK` variant when that lands).
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        rmp_serde::to_vec(self)
+    }
+
+    /// Deserialize from MessagePack bytes.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(rmp_serde::from_slice(buffer)?)
+    }
+}
+
+#[cfg(test)]
+mod tests_wire_count {
+    use super::*;
+
+    #[test]
+    fn test_new_empty() {
+        let cs = CountSketch::new(2, 3);
+        assert_eq!(cs.rows, 2);
+        assert_eq!(cs.cols, 3);
+        assert_eq!(cs.sketch(), &vec![vec![0.0, 0.0, 0.0], vec![0.0, 0.0, 0.0]]);
+    }
+
+    #[test]
+    fn test_from_legacy_matrix() {
+        let m = vec![vec![1.0, -2.0, 3.0], vec![-4.0, 5.0, -6.0]];
+        let cs = CountSketch::from_legacy_matrix(m.clone(), 2, 3);
+        assert_eq!(cs.sketch(), &m);
+    }
+
+    #[test]
+    fn test_merge_element_wise() {
+        let mut a = CountSketch::from_legacy_matrix(vec![vec![1.0, 2.0], vec![3.0, 4.0]], 2, 2);
+        let b = CountSketch::from_legacy_matrix(vec![vec![-1.0, -2.0], vec![-3.0, -4.0]], 2, 2);
+        a.merge(&b).unwrap();
+        assert_eq!(a.sketch(), &vec![vec![0.0, 0.0], vec![0.0, 0.0]]);
+    }
+
+    #[test]
+    fn test_merge_dimension_mismatch() {
+        let mut a = CountSketch::new(2, 3);
+        let b = CountSketch::new(3, 3);
+        assert!(a.merge(&b).is_err());
+    }
+
+    #[test]
+    fn test_merge_refs() {
+        let a = CountSketch::from_legacy_matrix(vec![vec![1.0, 2.0]], 1, 2);
+        let b = CountSketch::from_legacy_matrix(vec![vec![3.0, 4.0]], 1, 2);
+        let c = CountSketch::from_legacy_matrix(vec![vec![5.0, 6.0]], 1, 2);
+        let merged = CountSketch::merge_refs(&[&a, &b, &c]).unwrap();
+        assert_eq!(merged.sketch(), &vec![vec![9.0, 12.0]]);
+    }
+
+    #[test]
+    fn test_apply_delta_additive() {
+        let mut cs = CountSketch::from_legacy_matrix(
+            vec![vec![1.0, -2.0, 3.0], vec![-4.0, 5.0, -6.0]],
+            2,
+            3,
+        );
+        let delta = CountSketchDelta {
+            rows: 2,
+            cols: 3,
+            cells: vec![
+                (0, 0, 10),  // 1 + 10 = 11
+                (0, 2, -3),  // 3 - 3 = 0
+                (1, 1, -15), // 5 - 15 = -10
+            ],
+            l2: vec![],
+        };
+        cs.apply_delta(&delta).unwrap();
+        assert_eq!(
+            cs.sketch(),
+            &vec![vec![11.0, -2.0, 0.0], vec![-4.0, -10.0, -6.0]]
+        );
+    }
+
+    #[test]
+    fn test_apply_delta_matches_full_merge() {
+        let base = CountSketch::from_legacy_matrix(vec![vec![1.0, 2.0], vec![3.0, 4.0]], 2, 2);
+        let addition =
+            CountSketch::from_legacy_matrix(vec![vec![10.0, 0.0], vec![0.0, 20.0]], 2, 2);
+        let mut via_merge = base.clone();
+        via_merge.merge(&addition).unwrap();
+
+        let delta = CountSketchDelta {
+            rows: 2,
+            cols: 2,
+            cells: vec![(0, 0, 10), (1, 1, 20)],
+            l2: vec![],
+        };
+        let mut via_delta = base;
+        via_delta.apply_delta(&delta).unwrap();
+        assert_eq!(via_delta.sketch(), via_merge.sketch());
+    }
+
+    #[test]
+    fn test_apply_delta_out_of_range() {
+        let mut cs = CountSketch::new(2, 3);
+        let delta = CountSketchDelta {
+            rows: 2,
+            cols: 3,
+            cells: vec![(2, 0, 1)], // row 2 out of range for 2-row matrix
+            l2: vec![],
+        };
+        assert!(cs.apply_delta(&delta).is_err());
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let original =
+            CountSketch::from_legacy_matrix(vec![vec![1.5, -2.5], vec![3.5, -4.5]], 2, 2);
+        let bytes = original.serialize_msgpack().unwrap();
+        let decoded = CountSketch::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(decoded.sketch(), original.sketch());
+        assert_eq!(decoded.rows, original.rows);
+        assert_eq!(decoded.cols, original.cols);
+    }
+}

--- a/src/sketches/countmin.rs
+++ b/src/sketches/countmin.rs
@@ -960,3 +960,444 @@ mod tests {
         );
     }
 }
+
+// =====================================================================
+// asap_sketchlib wire-format-aligned variant.
+//
+// `CountMinSketch` and `CountMinDelta` below are the public-field,
+// proto-decode-friendly types consumed by the ASAP query engine
+// accumulators, backed by `asap_sketchlib`'s in-tree CountMin. The
+// high-throughput in-process variant above (`CountMin`) keeps its
+// original design.
+// =====================================================================
+
+// (de-duplicated) use serde::{Deserialize, Serialize};
+
+// ----- asap_sketchlib-backed Count-Min helpers -----
+// Used below by `CountMinSketch`. Lives in this file so the wire-format
+// type and its backend share a single home.
+
+/// Concrete Count-Min type backing the wire-format `CountMinSketch`.
+/// Uses f64 counters (`Vector2D<f64>`) for weighted updates without integer rounding.
+pub type SketchlibCms = CountMin<Vector2D<f64>, RegularPath>;
+
+/// Creates a fresh sketchlib Count-Min sketch with the given dimensions.
+pub fn new_sketchlib_cms(row_num: usize, col_num: usize) -> SketchlibCms {
+    SketchlibCms::with_dimensions(row_num, col_num)
+}
+
+/// Builds a sketchlib Count-Min sketch from an existing `sketch` matrix.
+pub fn sketchlib_cms_from_matrix(
+    row_num: usize,
+    col_num: usize,
+    sketch: &[Vec<f64>],
+) -> SketchlibCms {
+    let matrix = Vector2D::from_fn(row_num, col_num, |r, c| {
+        sketch
+            .get(r)
+            .and_then(|row| row.get(c))
+            .copied()
+            .unwrap_or(0.0)
+    });
+    SketchlibCms::from_storage(matrix)
+}
+
+/// Converts a sketchlib Count-Min sketch into a `Vec<Vec<f64>>` matrix.
+pub fn matrix_from_sketchlib_cms(inner: &SketchlibCms) -> Vec<Vec<f64>> {
+    let storage: &Vector2D<f64> = inner.as_storage();
+    let rows = storage.rows();
+    let cols = storage.cols();
+    let mut sketch = vec![vec![0.0; cols]; rows];
+
+    for (r, row) in sketch.iter_mut().enumerate().take(rows) {
+        for (c, cell) in row.iter_mut().enumerate().take(cols) {
+            if let Some(v) = storage.get(r, c) {
+                *cell = *v;
+            }
+        }
+    }
+
+    sketch
+}
+
+/// Helper to update a sketchlib Count-Min with a weighted key.
+pub fn sketchlib_cms_update(inner: &mut SketchlibCms, key: &str, value: f64) {
+    if value <= 0.0 {
+        return;
+    }
+    let input = DataInput::String(key.to_owned());
+    inner.insert_many(&input, value);
+}
+
+/// Helper to query a sketchlib Count-Min for a key, returning f64.
+pub fn sketchlib_cms_query(inner: &SketchlibCms, key: &str) -> f64 {
+    let input = DataInput::String(key.to_owned());
+    inner.estimate(&input)
+}
+
+#[derive(Serialize, Deserialize)]
+struct WireFormat {
+    sketch: Vec<Vec<f64>>,
+    #[serde(rename = "row_num")]
+    rows: usize,
+    #[serde(rename = "col_num")]
+    cols: usize,
+}
+
+/// Sparse delta between two consecutive CountMinSketch snapshots —
+/// the input shape for [`CountMinSketch::apply_delta`]. Mirrors the
+/// `CountMinSketchDelta` proto in
+/// `sketchlib-go/proto/countminsketch/countminsketch.proto` (packed
+/// encoding only).
+///
+/// Cells apply additively: `matrix[row][col] += d_count`. Per-row
+/// L1 and L2 norm deltas are carried for downstream error-accounting
+/// but are not consumed by `apply_delta` itself.
+#[derive(Debug, Clone, Default)]
+pub struct CountMinSketchDelta {
+    pub rows: u32,
+    pub cols: u32,
+    pub cells: Vec<(u32, u32, i64)>,
+    pub l1: Vec<f64>,
+    pub l2: Vec<f64>,
+}
+
+/// Provides approximate frequency counts with error bounds.
+/// The msgpack wire format is the contract between sketch producers and
+/// the query engine consumer.
+#[derive(Debug, Clone)]
+pub struct CountMinSketch {
+    pub rows: usize,
+    pub cols: usize,
+    pub(crate) backend: SketchlibCms,
+}
+
+impl CountMinSketch {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            backend: new_sketchlib_cms(rows, cols),
+        }
+    }
+
+    /// Number of hash rows in the sketch matrix.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns (width) in the sketch matrix.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    /// Returns the sketch matrix (for wire format, serialization, tests).
+    pub fn sketch(&self) -> Vec<Vec<f64>> {
+        matrix_from_sketchlib_cms(&self.backend)
+    }
+
+    /// Construct from a `Vec<Vec<f64>>` matrix (used by deserialization and query engine).
+    pub fn from_legacy_matrix(sketch: Vec<Vec<f64>>, rows: usize, cols: usize) -> Self {
+        Self {
+            rows,
+            cols,
+            backend: sketchlib_cms_from_matrix(rows, cols, &sketch),
+        }
+    }
+
+    pub fn update(&mut self, key: &str, value: f64) {
+        sketchlib_cms_update(&mut self.backend, key, value);
+    }
+
+    /// Estimate the frequency of `key` (CountMin point query).
+    pub fn estimate(&self, key: &str) -> f64 {
+        sketchlib_cms_query(&self.backend, key)
+    }
+
+    /// Merge another CountMinSketch into self in place. Both operands
+    /// must have identical dimensions.
+    pub fn merge(
+        &mut self,
+        other: &CountMinSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != other.rows || self.cols != other.cols {
+            return Err(format!(
+                "CountMinSketch dimension mismatch: self={}x{}, other={}x{}",
+                self.rows, self.cols, other.rows, other.cols
+            )
+            .into());
+        }
+        self.backend.merge(&other.backend);
+        Ok(())
+    }
+
+    /// Merge from references, allocating only the output — no input clones.
+    pub fn merge_refs(
+        accumulators: &[&Self],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if accumulators.is_empty() {
+            return Err("No accumulators to merge".into());
+        }
+
+        let rows = accumulators[0].rows;
+        let cols = accumulators[0].cols;
+
+        for acc in accumulators {
+            if acc.rows != rows || acc.cols != cols {
+                return Err(
+                    "Cannot merge CountMinSketch accumulators with different dimensions".into(),
+                );
+            }
+        }
+
+        let mut merged = CountMinSketch::new(rows, cols);
+        for acc in accumulators {
+            merged.backend.merge(&acc.backend);
+        }
+        Ok(merged)
+    }
+
+    /// Apply a sparse delta in place. Matches the `ApplyDelta`
+    /// semantics in `sketchlib-go/sketches/CountMinSketch/delta.go`:
+    /// `matrix[row][col] += d_count` for each cell in the delta.
+    ///
+    /// The FFI handle is opaque, so we snapshot the matrix, apply
+    /// cell updates, and rebuild the backend. The rebuild is
+    /// O(rows × cols) per delta and is acceptable for ingest-side
+    /// reconstitution — no delta should fire more than once per
+    /// window (10s–300s in the paper's B3 / B4 configs).
+    pub fn apply_delta(
+        &mut self,
+        delta: &CountMinSketchDelta,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for (row, col, _) in &delta.cells {
+            let r = *row as usize;
+            let c = *col as usize;
+            if r >= self.rows || c >= self.cols {
+                return Err(format!(
+                    "CountMinSketchDelta cell ({r},{c}) out of range (matrix={}x{})",
+                    self.rows, self.cols
+                )
+                .into());
+            }
+        }
+        let mut matrix = self.sketch();
+        for (row, col, d_count) in &delta.cells {
+            matrix[*row as usize][*col as usize] += *d_count as f64;
+        }
+        self.backend = sketchlib_cms_from_matrix(self.rows, self.cols, &matrix);
+        Ok(())
+    }
+
+    /// Serialize to MessagePack — matches the wire format exactly.
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        let sketch = self.sketch();
+        let wire = WireFormat {
+            sketch,
+            rows: self.rows,
+            cols: self.cols,
+        };
+
+        let mut buf = Vec::new();
+        wire.serialize(&mut rmp_serde::Serializer::new(&mut buf))?;
+        Ok(buf)
+    }
+
+    /// Deserialize from MessagePack.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let wire: WireFormat = rmp_serde::from_slice(buffer).map_err(
+            |e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to deserialize CountMinSketch from MessagePack: {e}").into()
+            },
+        )?;
+
+        let backend = sketchlib_cms_from_matrix(wire.rows, wire.cols, &wire.sketch);
+
+        Ok(Self {
+            rows: wire.rows,
+            cols: wire.cols,
+            backend,
+        })
+    }
+
+    /// One-shot aggregation: build a sketch from parallel key/value slices
+    /// and return the msgpack bytes.
+    pub fn aggregate_count(
+        depth: usize,
+        width: usize,
+        keys: &[&str],
+        values: &[f64],
+    ) -> Option<Vec<u8>> {
+        if keys.is_empty() {
+            return None;
+        }
+        let mut sketch = Self::new(depth, width);
+        for (key, &value) in keys.iter().zip(values.iter()) {
+            sketch.update(key, value);
+        }
+        sketch.serialize_msgpack().ok()
+    }
+
+    /// Same as aggregate_count — CMS accumulates sums by construction.
+    pub fn aggregate_sum(
+        depth: usize,
+        width: usize,
+        keys: &[&str],
+        values: &[f64],
+    ) -> Option<Vec<u8>> {
+        Self::aggregate_count(depth, width, keys, values)
+    }
+}
+
+#[cfg(test)]
+mod tests_wire_countmin {
+    use super::*;
+
+    #[test]
+    fn test_count_min_sketch_creation() {
+        let cms = CountMinSketch::new(4, 1000);
+        assert_eq!(cms.rows, 4);
+        assert_eq!(cms.cols, 1000);
+        let sketch = cms.sketch();
+        assert_eq!(sketch.len(), 4);
+        assert_eq!(sketch[0].len(), 1000);
+
+        // Check all values are initialized to 0
+        for row in &sketch {
+            for &value in row {
+                assert_eq!(value, 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_count_min_sketch_update() {
+        let mut cms = CountMinSketch::new(2, 10);
+        cms.update("key1", 1.0);
+        // Query should return at least the updated value
+        let result = cms.estimate("key1");
+        assert!(result >= 1.0);
+    }
+
+    #[test]
+    fn test_count_min_sketch_query_empty() {
+        let cms = CountMinSketch::new(2, 10);
+        assert_eq!(cms.estimate("anything"), 0.0);
+    }
+
+    #[test]
+    fn test_count_min_sketch_merge() {
+        // Use from_legacy_matrix so the test works regardless of sketchlib/legacy config
+        let mut sketch1 = vec![vec![0.0; 3]; 2];
+        sketch1[0][0] = 5.0;
+        sketch1[1][2] = 10.0;
+        let mut cms1 = CountMinSketch::from_legacy_matrix(sketch1, 2, 3);
+
+        let mut sketch2 = vec![vec![0.0; 3]; 2];
+        sketch2[0][0] = 3.0;
+        sketch2[0][1] = 7.0;
+        let cms2 = CountMinSketch::from_legacy_matrix(sketch2, 2, 3);
+
+        cms1.merge(&cms2).unwrap();
+        let merged_sketch = cms1.sketch();
+
+        assert_eq!(merged_sketch[0][0], 8.0); // 5 + 3
+        assert_eq!(merged_sketch[0][1], 7.0); // 0 + 7
+        assert_eq!(merged_sketch[1][2], 10.0); // 10 + 0
+    }
+
+    #[test]
+    fn test_count_min_sketch_merge_dimension_mismatch() {
+        let mut cms1 = CountMinSketch::new(2, 3);
+        let cms2 = CountMinSketch::new(3, 3);
+        assert!(cms1.merge(&cms2).is_err());
+    }
+
+    #[test]
+    fn test_count_min_sketch_msgpack_round_trip() {
+        let mut cms = CountMinSketch::new(4, 256);
+        cms.update("apple", 5.0);
+        cms.update("banana", 3.0);
+        cms.update("apple", 2.0); // total "apple" = 7
+
+        let bytes = cms.serialize_msgpack().unwrap();
+        let deserialized = CountMinSketch::deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(deserialized.rows, 4);
+        assert_eq!(deserialized.cols, 256);
+        assert!(deserialized.estimate("apple") >= 7.0);
+        assert!(deserialized.estimate("banana") >= 3.0);
+    }
+
+    #[test]
+    fn test_aggregate_count() {
+        let keys = ["a", "b", "a"];
+        let values = [1.0, 2.0, 3.0];
+        let bytes = CountMinSketch::aggregate_count(4, 100, &keys, &values).unwrap();
+        let cms = CountMinSketch::deserialize_msgpack(&bytes).unwrap();
+        // "a" was updated twice (1.0 + 3.0 = 4.0), "b" once (2.0)
+        assert!(cms.estimate("a") >= 4.0);
+        assert!(cms.estimate("b") >= 2.0);
+    }
+
+    #[test]
+    fn test_aggregate_count_empty() {
+        assert!(CountMinSketch::aggregate_count(4, 100, &[], &[]).is_none());
+    }
+
+    #[test]
+    fn test_apply_delta_additive() {
+        let mut cms = CountMinSketch::from_legacy_matrix(
+            vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
+            2,
+            3,
+        );
+        let delta = CountMinSketchDelta {
+            rows: 2,
+            cols: 3,
+            cells: vec![(0, 0, 10), (1, 2, 100)],
+            l1: vec![],
+            l2: vec![],
+        };
+        cms.apply_delta(&delta).unwrap();
+        assert_eq!(
+            cms.sketch(),
+            vec![vec![11.0, 2.0, 3.0], vec![4.0, 5.0, 106.0]]
+        );
+    }
+
+    #[test]
+    fn test_apply_delta_matches_full_merge() {
+        let base = CountMinSketch::from_legacy_matrix(vec![vec![1.0, 2.0], vec![3.0, 4.0]], 2, 2);
+        let addition =
+            CountMinSketch::from_legacy_matrix(vec![vec![10.0, 0.0], vec![0.0, 20.0]], 2, 2);
+        let mut via_merge = base.clone();
+        via_merge.merge(&addition).unwrap();
+
+        let delta = CountMinSketchDelta {
+            rows: 2,
+            cols: 2,
+            cells: vec![(0, 0, 10), (1, 1, 20)],
+            l1: vec![],
+            l2: vec![],
+        };
+        let mut via_delta = base;
+        via_delta.apply_delta(&delta).unwrap();
+        assert_eq!(via_delta.sketch(), via_merge.sketch());
+    }
+
+    #[test]
+    fn test_apply_delta_out_of_range() {
+        let mut cms = CountMinSketch::new(2, 3);
+        let delta = CountMinSketchDelta {
+            rows: 2,
+            cols: 3,
+            cells: vec![(5, 0, 1)],
+            l1: vec![],
+            l2: vec![],
+        };
+        assert!(cms.apply_delta(&delta).is_err());
+    }
+}

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -742,3 +742,609 @@ mod tests {
         }
     }
 }
+
+// =====================================================================
+// ASAP runtime wire-format-aligned variant .
+//
+// `DdSketch` and `DdSketchDelta` below are the public-field,
+// proto-decode-friendly types consumed by the ASAP query engine
+// accumulators. The high-throughput in-process variant above
+// (`DDSketch`) keeps its original design.
+// =====================================================================
+
+// DDSketch — log-bucketed quantile sketch, mergeable by store-index alignment.
+//
+// Parallel to `count_sketch::CountSketch`: the minimum viable surface
+// needed for the modified-OTLP `Metric.data = DDSketch{…}` hot path
+// (PR C-CountSketch follow-up). Holds the bucket counts, their
+// absolute-index base offset, and the aggregate `{count, sum, min, max}`.
+//
+// Merge semantics: two sketches with the same relative-accuracy
+// parameter `alpha` are merged by aligning bucket arrays along their
+// `store_offset` and summing counts element-wise, with `min`/`max`
+// combined via min/max and `count`/`sum` added.
+//
+// The wire format is the protobuf-encoded
+// `asap_sketchlib::proto::sketchlib::DDSketchState` emitted by
+// DataCollector's `ddsketchprocessor`. Quantile estimation against
+// stored data is intentionally deferred — queries currently return
+// a placeholder error and fall through to the §5.2 fallback.
+
+// (de-duplicated) use serde::{Deserialize, Serialize};
+
+/// Sparse delta between two consecutive DDSketch snapshots — the
+/// input shape for [`DdSketch::apply_delta`]. Mirrors the
+/// `DDSketchDelta` proto in `sketchlib-go/proto/ddsketch/ddsketch.proto`
+/// (and its Rust bindings vendored in `asap_otel_proto::sketchlib::v1`).
+/// Kept as a plain struct so this crate doesn't need a tonic/prost
+/// dependency; proto decode lives in the accumulator.
+#[derive(Debug, Clone, Default)]
+pub struct DdSketchDelta {
+    /// `(absolute_bucket_index, Δcount)` pairs, additive.
+    pub buckets: Vec<(i32, u64)>,
+    /// Δ total count. May be negative (signed on the wire).
+    pub d_count: i64,
+    /// Δ sum.
+    pub d_sum: f64,
+    /// Whether `new_min` carries a meaningful value. Min can only
+    /// decrease; a delta that didn't lower min sends `false`.
+    pub min_changed: bool,
+    pub new_min: f64,
+    /// Whether `new_max` carries a meaningful value. Max can only
+    /// increase.
+    pub max_changed: bool,
+    pub new_max: f64,
+}
+
+/// Minimal DDSketch state — bucket counts + alpha + aggregates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DdSketch {
+    /// Relative accuracy parameter; must satisfy `0 < alpha < 1`.
+    pub alpha: f64,
+    /// Bucket counts in absolute-index order. The absolute index of
+    /// `store_counts[i]` is `i + store_offset`.
+    pub store_counts: Vec<u64>,
+    /// Absolute bucket index corresponding to `store_counts[0]`. May
+    /// be negative.
+    pub store_offset: i32,
+    pub count: u64,
+    pub sum: f64,
+    pub min: f64,
+    pub max: f64,
+}
+
+impl DdSketch {
+    /// Construct an empty sketch.
+    pub fn new(alpha: f64) -> Self {
+        Self {
+            alpha,
+            store_counts: Vec::new(),
+            store_offset: 0,
+            count: 0,
+            sum: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        }
+    }
+
+    /// Construct from the decoded wire fields.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_raw(
+        alpha: f64,
+        store_counts: Vec<u64>,
+        store_offset: i32,
+        count: u64,
+        sum: f64,
+        min: f64,
+        max: f64,
+    ) -> Self {
+        Self {
+            alpha,
+            store_counts,
+            store_offset,
+            count,
+            sum,
+            min,
+            max,
+        }
+    }
+
+    /// Merge one other sketch into self by aligning bucket arrays on
+    /// absolute indices. Both operands must share the same `alpha`.
+    pub fn merge(
+        &mut self,
+        other: &DdSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if (self.alpha - other.alpha).abs() > f64::EPSILON {
+            return Err(format!(
+                "DdSketch alpha mismatch: self={}, other={}",
+                self.alpha, other.alpha
+            )
+            .into());
+        }
+
+        if other.store_counts.is_empty() {
+            self.count += other.count;
+            self.sum += other.sum;
+            if other.min < self.min {
+                self.min = other.min;
+            }
+            if other.max > self.max {
+                self.max = other.max;
+            }
+            return Ok(());
+        }
+        if self.store_counts.is_empty() {
+            self.store_counts = other.store_counts.clone();
+            self.store_offset = other.store_offset;
+        } else {
+            let self_start = self.store_offset as i64;
+            let self_end = self_start + self.store_counts.len() as i64;
+            let other_start = other.store_offset as i64;
+            let other_end = other_start + other.store_counts.len() as i64;
+            let new_start = self_start.min(other_start);
+            let new_end = self_end.max(other_end);
+            let new_len = (new_end - new_start) as usize;
+            let mut merged = vec![0u64; new_len];
+            for (i, c) in self.store_counts.iter().enumerate() {
+                let idx = (self_start + i as i64 - new_start) as usize;
+                merged[idx] = merged[idx].saturating_add(*c);
+            }
+            for (i, c) in other.store_counts.iter().enumerate() {
+                let idx = (other_start + i as i64 - new_start) as usize;
+                merged[idx] = merged[idx].saturating_add(*c);
+            }
+            self.store_counts = merged;
+            self.store_offset = new_start as i32;
+        }
+        self.count += other.count;
+        self.sum += other.sum;
+        if other.min < self.min {
+            self.min = other.min;
+        }
+        if other.max > self.max {
+            self.max = other.max;
+        }
+        Ok(())
+    }
+
+    /// Apply a sparse delta to this sketch in place. Matches the
+    /// `ApplyDelta` logic in `sketchlib-go/sketches/DDSketch/delta.go`:
+    /// bucket counts add, total count + sum add, min can only decrease
+    /// and max can only increase. Used by the backend ingest path to
+    /// reconstitute a full sketch from a base snapshot + subsequent
+    /// delta-transmission frames (paper §6.2 B3 / B4 baselines).
+    pub fn apply_delta(&mut self, delta: &DdSketchDelta) {
+        for (abs_idx, d_count) in &delta.buckets {
+            if self.store_counts.is_empty() {
+                self.store_counts = vec![0u64; 1];
+                self.store_offset = *abs_idx;
+            }
+            let cur_start = self.store_offset as i64;
+            let cur_end = cur_start + self.store_counts.len() as i64;
+            let k = *abs_idx as i64;
+            if k < cur_start {
+                // Prepend zeros.
+                let pad = (cur_start - k) as usize;
+                let mut buf = vec![0u64; pad];
+                buf.append(&mut self.store_counts);
+                self.store_counts = buf;
+                self.store_offset = *abs_idx;
+            } else if k >= cur_end {
+                let pad = (k - cur_end + 1) as usize;
+                self.store_counts.extend(std::iter::repeat_n(0u64, pad));
+            }
+            let arr_idx = (k - self.store_offset as i64) as usize;
+            self.store_counts[arr_idx] = self.store_counts[arr_idx].saturating_add(*d_count);
+        }
+        if delta.d_count >= 0 {
+            self.count = self.count.saturating_add(delta.d_count as u64);
+        } else {
+            self.count = self.count.saturating_sub((-delta.d_count) as u64);
+        }
+        self.sum += delta.d_sum;
+        if delta.min_changed && delta.new_min < self.min {
+            self.min = delta.new_min;
+        }
+        if delta.max_changed && delta.new_max > self.max {
+            self.max = delta.new_max;
+        }
+    }
+
+    /// Merge a slice of references into a single new sketch. Returns
+    /// `Err` on alpha mismatch or an empty input.
+    pub fn merge_refs(
+        inputs: &[&DdSketch],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let first = inputs
+            .first()
+            .ok_or("DdSketch::merge_refs called with empty input")?;
+        let mut merged = DdSketch::new(first.alpha);
+        for d in inputs {
+            merged.merge(d)?;
+        }
+        Ok(merged)
+    }
+
+    /// Insert a single positive value. Updates count, sum, min/max
+    /// and increments the bucket for `floor(ln(v) / ln(gamma))`
+    /// where `gamma = (1+α)/(1-α)`. Provided primarily so tests can
+    /// build a ground-truth sketch to compare delta-apply output
+    /// against.
+    pub fn update(&mut self, value: f64) {
+        if value <= 0.0 {
+            // DDSketch is defined for positive reals; the paper's
+            // sketchlib-go rejects non-positive values silently.
+            return;
+        }
+        let gamma = (1.0 + self.alpha) / (1.0 - self.alpha);
+        let ln_gamma = gamma.ln();
+        let idx = (value.ln() / ln_gamma).floor() as i32;
+        if self.store_counts.is_empty() {
+            self.store_counts = vec![1];
+            self.store_offset = idx;
+        } else {
+            let cur_start = self.store_offset as i64;
+            let cur_end = cur_start + self.store_counts.len() as i64;
+            let k = idx as i64;
+            if k < cur_start {
+                let pad = (cur_start - k) as usize;
+                let mut buf = vec![0u64; pad];
+                buf.append(&mut self.store_counts);
+                self.store_counts = buf;
+                self.store_offset = idx;
+            } else if k >= cur_end {
+                let pad = (k - cur_end + 1) as usize;
+                self.store_counts.extend(std::iter::repeat_n(0u64, pad));
+            }
+            let arr_idx = (k - self.store_offset as i64) as usize;
+            self.store_counts[arr_idx] = self.store_counts[arr_idx].saturating_add(1);
+        }
+        self.count = self.count.saturating_add(1);
+        self.sum += value;
+        if value < self.min {
+            self.min = value;
+        }
+        if value > self.max {
+            self.max = value;
+        }
+    }
+
+    /// Estimate the quantile at rank `q` ∈ [0, 1]. Walks the bucket
+    /// array in ascending absolute-index order, accumulating counts
+    /// until the target rank; returns the bucket's representative
+    /// value `gamma^(k + 0.5)` where `k` is the bucket's absolute
+    /// index. Returns `None` if the sketch is empty.
+    ///
+    /// Accuracy: bounded by DDSketch's α parameter — the estimated
+    /// quantile value is within `(1+α)/(1-α)` relative error of the
+    /// true quantile.
+    pub fn quantile(&self, q: f64) -> Option<f64> {
+        if self.count == 0 || self.store_counts.is_empty() {
+            return None;
+        }
+        let target = (q * (self.count.saturating_sub(1)) as f64).floor() as u64;
+        let mut cumulative: u64 = 0;
+        let gamma = (1.0 + self.alpha) / (1.0 - self.alpha);
+        for (i, &c) in self.store_counts.iter().enumerate() {
+            cumulative = cumulative.saturating_add(c);
+            if cumulative > target {
+                let k = (self.store_offset as i64 + i as i64) as f64;
+                // Bucket midpoint: gamma^(k + 0.5) — centers the
+                // estimate in the logarithmic bucket.
+                return Some(gamma.powf(k + 0.5));
+            }
+        }
+        // Numerical edge case: if we fall off the end, return max.
+        Some(self.max)
+    }
+
+    /// Serialize to MessagePack bytes.
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        rmp_serde::to_vec(self)
+    }
+
+    /// Deserialize from MessagePack bytes.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(rmp_serde::from_slice(buffer)?)
+    }
+}
+
+#[cfg(test)]
+mod tests_wire_ddsketch {
+    use super::*;
+
+    #[test]
+    fn test_new_empty() {
+        let d = DdSketch::new(0.01);
+        assert_eq!(d.count, 0);
+        assert!(d.store_counts.is_empty());
+        assert_eq!(d.min, f64::INFINITY);
+        assert_eq!(d.max, f64::NEG_INFINITY);
+    }
+
+    #[test]
+    fn test_merge_aligned_same_offset() {
+        let mut a = DdSketch::from_raw(0.01, vec![1, 2, 3], -1, 6, 30.0, 1.0, 5.0);
+        let b = DdSketch::from_raw(0.01, vec![10, 20, 30], -1, 60, 300.0, 0.5, 6.0);
+        a.merge(&b).unwrap();
+        assert_eq!(a.store_counts, vec![11, 22, 33]);
+        assert_eq!(a.store_offset, -1);
+        assert_eq!(a.count, 66);
+        assert_eq!(a.sum, 330.0);
+        assert_eq!(a.min, 0.5);
+        assert_eq!(a.max, 6.0);
+    }
+
+    #[test]
+    fn test_merge_overlapping_offsets() {
+        // a covers indices [-1, 0, 1]; b covers indices [0, 1, 2]
+        let mut a = DdSketch::from_raw(0.01, vec![1, 1, 1], -1, 3, 3.0, 1.0, 3.0);
+        let b = DdSketch::from_raw(0.01, vec![10, 10, 10], 0, 30, 30.0, 1.0, 3.0);
+        a.merge(&b).unwrap();
+        // Merged window is [-1, 0, 1, 2] → [1, 11, 11, 10]
+        assert_eq!(a.store_counts, vec![1, 11, 11, 10]);
+        assert_eq!(a.store_offset, -1);
+        assert_eq!(a.count, 33);
+    }
+
+    #[test]
+    fn test_merge_disjoint_offsets() {
+        let mut a = DdSketch::from_raw(0.01, vec![1, 2], 0, 3, 3.0, 1.0, 2.0);
+        let b = DdSketch::from_raw(0.01, vec![3, 4], 5, 7, 7.0, 5.0, 6.0);
+        a.merge(&b).unwrap();
+        // Window [0..7) → [1,2,0,0,0,3,4]
+        assert_eq!(a.store_counts, vec![1, 2, 0, 0, 0, 3, 4]);
+        assert_eq!(a.store_offset, 0);
+    }
+
+    #[test]
+    fn test_apply_delta_additive_inside_store() {
+        let mut base = DdSketch::from_raw(0.01, vec![1, 2, 3], -1, 6, 30.0, 1.0, 5.0);
+        let delta = DdSketchDelta {
+            buckets: vec![(-1, 4), (0, 8), (1, 12)],
+            d_count: 24,
+            d_sum: 120.0,
+            min_changed: false,
+            new_min: 0.0,
+            max_changed: true,
+            new_max: 9.0,
+        };
+        base.apply_delta(&delta);
+        assert_eq!(base.store_counts, vec![5, 10, 15]);
+        assert_eq!(base.count, 30);
+        assert_eq!(base.sum, 150.0);
+        assert_eq!(base.min, 1.0);
+        assert_eq!(base.max, 9.0);
+    }
+
+    #[test]
+    fn test_apply_delta_expands_store_on_new_bucket() {
+        // Base covers [0..2]; delta adds a bucket at absolute index 4.
+        let mut base = DdSketch::from_raw(0.01, vec![1, 2], 0, 3, 3.0, 1.0, 2.0);
+        let delta = DdSketchDelta {
+            buckets: vec![(4, 7)],
+            d_count: 7,
+            d_sum: 35.0,
+            min_changed: false,
+            new_min: 0.0,
+            max_changed: true,
+            new_max: 6.0,
+        };
+        base.apply_delta(&delta);
+        assert_eq!(base.store_counts, vec![1, 2, 0, 0, 7]);
+        assert_eq!(base.store_offset, 0);
+        assert_eq!(base.count, 10);
+        assert_eq!(base.max, 6.0);
+    }
+
+    #[test]
+    fn test_apply_delta_matches_full_merge() {
+        // Snapshot the sketch, add more samples via a merge, and confirm
+        // the delta+apply path lands at the same state.
+        let base = DdSketch::from_raw(0.01, vec![1, 2, 3], 0, 6, 12.0, 1.0, 3.0);
+        let addition = DdSketch::from_raw(0.01, vec![10, 0, 20], 0, 30, 70.0, 0.5, 5.0);
+        let mut via_merge = base.clone();
+        via_merge.merge(&addition).unwrap();
+
+        let delta = DdSketchDelta {
+            buckets: vec![(0, 10), (2, 20)],
+            d_count: 30,
+            d_sum: 70.0,
+            min_changed: true,
+            new_min: 0.5,
+            max_changed: true,
+            new_max: 5.0,
+        };
+        let mut via_delta = base;
+        via_delta.apply_delta(&delta);
+
+        assert_eq!(via_delta.store_counts, via_merge.store_counts);
+        assert_eq!(via_delta.count, via_merge.count);
+        assert_eq!(via_delta.sum, via_merge.sum);
+        assert_eq!(via_delta.min, via_merge.min);
+        assert_eq!(via_delta.max, via_merge.max);
+    }
+
+    #[test]
+    fn test_merge_alpha_mismatch() {
+        let mut a = DdSketch::new(0.01);
+        let b = DdSketch::new(0.02);
+        assert!(a.merge(&b).is_err());
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let original = DdSketch::from_raw(0.01, vec![1, 2, 3], -2, 6, 30.0, 1.0, 5.0);
+        let bytes = original.serialize_msgpack().unwrap();
+        let decoded = DdSketch::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(decoded.store_counts, original.store_counts);
+        assert_eq!(decoded.store_offset, original.store_offset);
+        assert_eq!(decoded.count, original.count);
+    }
+
+    #[test]
+    fn test_insert_and_quantile_lognormal() {
+        // Ground-truth: insert a large i.i.d. log-normal sample into
+        // a full sketch and sanity-check P50 / P90 / P99.
+        let mut gt = DdSketch::new(0.01);
+        let mut rng = 0xdead_beefu64;
+        let mut next = || {
+            // xorshift64*
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            rng
+        };
+        // Box-Muller normal → log-normal(mu=3, sigma=0.7).
+        let lognormal = |u: u64, v: u64| -> f64 {
+            let r1 = (u as f64) / (u64::MAX as f64).max(1.0);
+            let r2 = (v as f64) / (u64::MAX as f64).max(1.0);
+            let z = (-2.0 * r1.max(1e-12).ln()).sqrt() * (2.0 * std::f64::consts::PI * r2).cos();
+            (3.0 + 0.7 * z).exp()
+        };
+        for _ in 0..100_000 {
+            gt.update(lognormal(next(), next()));
+        }
+        let p50 = gt.quantile(0.5).unwrap();
+        let p99 = gt.quantile(0.99).unwrap();
+        // Analytical P50 = exp(mu) = e^3 ≈ 20.09;
+        // P99 ≈ exp(mu + sigma * Φ⁻¹(0.99)) = e^(3 + 0.7×2.326) ≈ 102.4.
+        assert!(
+            (p50 / 20.09).ln().abs() < 0.05,
+            "P50 {} not close to 20.09",
+            p50
+        );
+        assert!(
+            (p99 / 102.4).ln().abs() < 0.05,
+            "P99 {} not close to 102.4",
+            p99
+        );
+    }
+
+    /// Core accuracy claim for PRs #60-#63 end-to-end: building a
+    /// sketch via `base + apply_delta()` produces quantile estimates
+    /// within DDSketch's α bound of the ground-truth full-sketch
+    /// path. If this fails, the paper's delta-reconstitution story
+    /// is broken.
+    #[test]
+    fn test_delta_chain_preserves_quantile_accuracy() {
+        let alpha = 0.01;
+        let mut rng = 0xcafe_babeu64;
+        let mut next = || {
+            rng ^= rng << 13;
+            rng ^= rng >> 7;
+            rng ^= rng << 17;
+            rng
+        };
+        let lognormal = |u: u64, v: u64| -> f64 {
+            let r1 = (u as f64) / (u64::MAX as f64).max(1.0);
+            let r2 = (v as f64) / (u64::MAX as f64).max(1.0);
+            let z = (-2.0 * r1.max(1e-12).ln()).sqrt() * (2.0 * std::f64::consts::PI * r2).cos();
+            (3.0 + 0.7 * z).exp()
+        };
+
+        // Path A (ground truth): one sketch, 50k samples inserted
+        // directly.
+        let mut full = DdSketch::new(alpha);
+        // Path B (delta chain): a base sketch from the first 10k
+        // samples, then 4 incremental "flushes" of 10k samples each,
+        // each transmitted as a delta computed against the previous
+        // snapshot.
+        let mut reconstituted = DdSketch::new(alpha);
+        let mut prev_snapshot = DdSketch::new(alpha); // what the "receiver" has cached
+
+        let batch = 10_000;
+        let batches = 5;
+        for b in 0..batches {
+            let mut this_batch = prev_snapshot.clone();
+            for _ in 0..batch {
+                let v = lognormal(next(), next());
+                full.update(v);
+                this_batch.update(v);
+            }
+            // Compute a "delta" = diff of this_batch vs prev_snapshot
+            // in our in-memory struct shape. Matches what
+            // `sketchlib-go/sketches/DDSketch/delta.go::ComputeDelta`
+            // would put on the wire.
+            let delta = compute_dd_delta(&prev_snapshot, &this_batch);
+            if b == 0 {
+                // First batch seeds the reconstituted sketch.
+                reconstituted = this_batch.clone();
+            } else {
+                reconstituted.apply_delta(&delta);
+            }
+            prev_snapshot = this_batch;
+        }
+
+        // Both paths should see the same total count + sum (exact).
+        assert_eq!(reconstituted.count, full.count, "count diverged");
+        assert!(
+            (reconstituted.sum - full.sum).abs() < 1e-6,
+            "sum diverged: recon={} full={}",
+            reconstituted.sum,
+            full.sum
+        );
+
+        // And P50 / P90 / P99 should agree within α bound.
+        for q in [0.5, 0.9, 0.99] {
+            let got = reconstituted.quantile(q).unwrap();
+            let want = full.quantile(q).unwrap();
+            let rel_err = (got / want - 1.0).abs();
+            assert!(
+                rel_err <= alpha,
+                "q={} rel_err={:.4} exceeds α={}: reconstituted={}, full={}",
+                q,
+                rel_err,
+                alpha,
+                got,
+                want,
+            );
+        }
+    }
+
+    /// Helper used only in the delta-chain test: computes a
+    /// `DdSketchDelta` from two snapshots. Mirrors the sketchlib-go
+    /// `ComputeDelta` logic so the test exercises the wire-format
+    /// path end-to-end.
+    fn compute_dd_delta(snapshot: &DdSketch, current: &DdSketch) -> DdSketchDelta {
+        let mut cells = Vec::new();
+        if !current.store_counts.is_empty() {
+            for (i, &c) in current.store_counts.iter().enumerate() {
+                if c == 0 {
+                    continue;
+                }
+                let k = current.store_offset + i as i32;
+                let snap_count: u64 = if !snapshot.store_counts.is_empty() {
+                    let idx = k as i64 - snapshot.store_offset as i64;
+                    if idx >= 0 && (idx as usize) < snapshot.store_counts.len() {
+                        snapshot.store_counts[idx as usize]
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                };
+                let dc = c.saturating_sub(snap_count);
+                if dc > 0 {
+                    cells.push((k, dc));
+                }
+            }
+        }
+        let d_count = current.count as i64 - snapshot.count as i64;
+        let d_sum = current.sum - snapshot.sum;
+        let min_changed = current.count > 0 && (snapshot.count == 0 || current.min < snapshot.min);
+        let max_changed = current.count > 0 && (snapshot.count == 0 || current.max > snapshot.max);
+        DdSketchDelta {
+            buckets: cells,
+            d_count,
+            d_sum,
+            min_changed,
+            new_min: current.min,
+            max_changed,
+            new_max: current.max,
+        }
+    }
+}

--- a/src/sketches/delta_set_aggregator.rs
+++ b/src/sketches/delta_set_aggregator.rs
@@ -1,0 +1,72 @@
+// Wire format for the delta set aggregator: `DeltaResult` plus module-level
+// `serialize_msgpack` / `deserialize_msgpack` free functions. Streaming
+// logic (window tracking, stateful accumulation) stays upstream — only the
+// over-the-wire shape lives here.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Wire format for the delta set aggregator — shared between producer and consumer.
+/// Both sides agree on `{ added: HashSet<String>, removed: HashSet<String> }` in msgpack.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DeltaResult {
+    pub added: HashSet<String>,
+    pub removed: HashSet<String>,
+}
+
+/// Serialize a delta result to MessagePack.
+pub fn serialize_msgpack(
+    added: &HashSet<String>,
+    removed: &HashSet<String>,
+) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    let result = DeltaResult {
+        added: added.clone(),
+        removed: removed.clone(),
+    };
+    let mut buf = Vec::new();
+    rmp_serde::encode::write(&mut buf, &result)?;
+    Ok(buf)
+}
+
+/// Deserialize a delta result from MessagePack.
+pub fn deserialize_msgpack(
+    buffer: &[u8],
+) -> Result<DeltaResult, Box<dyn std::error::Error + Send + Sync>> {
+    rmp_serde::from_slice(buffer).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+        format!("Failed to deserialize DeltaResult from MessagePack: {e}").into()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let mut added = HashSet::new();
+        added.insert("web".to_string());
+        added.insert("api".to_string());
+
+        let mut removed = HashSet::new();
+        removed.insert("db".to_string());
+
+        let bytes = serialize_msgpack(&added, &removed).unwrap();
+        let result = deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(result.added.len(), 2);
+        assert!(result.added.contains("web"));
+        assert!(result.added.contains("api"));
+        assert_eq!(result.removed.len(), 1);
+        assert!(result.removed.contains("db"));
+    }
+
+    #[test]
+    fn test_empty_sets() {
+        let added = HashSet::new();
+        let removed = HashSet::new();
+        let bytes = serialize_msgpack(&added, &removed).unwrap();
+        let result = deserialize_msgpack(&bytes).unwrap();
+        assert!(result.added.is_empty());
+        assert!(result.removed.is_empty());
+    }
+}

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -883,3 +883,387 @@ mod tests {
         );
     }
 }
+
+// =====================================================================
+// ASAP runtime wire-format-aligned variant .
+//
+// `HllSketch` and `HllSketchDelta` below are the public-field,
+// proto-decode-friendly types consumed by the ASAP query engine
+// accumulators. The high-throughput in-process variant above
+// (`HyperLogLogImpl`/`HyperLogLog`) keeps its original design. Note:
+// the wire-format delta type was renamed `HllDelta` -> `HllSketchDelta`
+// to avoid collision with `octo_delta::HllDelta` (single-register,
+// octo-runtime path).
+// =====================================================================
+
+// HyperLogLog sketch — register-wise mergeable cardinality estimator.
+//
+// Parallel to `count_sketch::CountSketch`: the minimum viable surface
+// needed for the modified-OTLP `Metric.data = HLLSketch{…}` hot path
+// (PR C-CountSketch follow-up). Wraps a flat `Vec<u8>` of register
+// values (length = `2^precision`) and merges element-wise by taking
+// the maximum across aligned registers, which is the standard HLL
+// merge semantics.
+//
+// The wire format is the protobuf-encoded
+// `asap_sketchlib::proto::sketchlib::HyperLogLogState` emitted by
+// DataCollector's `hllprocessor`. This type carries the register
+// bytes and the variant/precision metadata losslessly, so the
+// merge + store round-trip works end-to-end. Cardinality estimation
+// against stored HLL data is intentionally deferred to a follow-up
+// — queries currently return a placeholder error and fall through
+// to the §5.2 fallback.
+
+// (de-duplicated) use serde::{Deserialize, Serialize};
+
+/// HLL estimator variant. Mirrors `asap_sketchlib::proto::sketchlib::HllVariant`
+/// so the proto round-trip preserves the algorithm identity — the three
+/// variants are not mutually compatible on register contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HllVariant {
+    Unspecified,
+    Regular,
+    Datafusion,
+    Hip,
+}
+
+/// Sparse delta between two consecutive HLL snapshots — the input
+/// shape for [`HllSketch::apply_delta`]. Mirrors the `HLLDelta` proto
+/// in `sketchlib-go/proto/hll/hll.proto` (and its Rust bindings
+/// vendored in `asap_otel_proto::sketchlib::v1`). HLL registers merge
+/// with max semantics, so a delta carries only the register indices
+/// whose value increased since the last snapshot.
+#[derive(Debug, Clone, Default)]
+pub struct HllSketchDelta {
+    /// `(register_index, new_value)` pairs. `new_value` is the full
+    /// post-update register value; `apply_delta` does
+    /// `registers[i] = max(registers[i], new_value)`.
+    pub updates: Vec<(u32, u8)>,
+}
+
+/// Minimal HLL state — registers + variant + precision. Register-wise
+/// mergeable (max over aligned cells).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HllSketch {
+    pub variant: HllVariant,
+    pub precision: u32,
+    /// Flat register array, length = `2^precision`.
+    pub registers: Vec<u8>,
+    /// HIP accumulator components — populated only when `variant == Hip`.
+    pub hip_kxq0: f64,
+    pub hip_kxq1: f64,
+    pub hip_est: f64,
+}
+
+impl HllSketch {
+    /// Construct an empty sketch at the given precision.
+    pub fn new(variant: HllVariant, precision: u32) -> Self {
+        let n = 1usize << precision;
+        Self {
+            variant,
+            precision,
+            registers: vec![0u8; n],
+            hip_kxq0: 0.0,
+            hip_kxq1: 0.0,
+            hip_est: 0.0,
+        }
+    }
+
+    /// Construct from pre-built register bytes (used by the modified-OTLP
+    /// proto-decode path).
+    pub fn from_raw(
+        variant: HllVariant,
+        precision: u32,
+        registers: Vec<u8>,
+        hip_kxq0: f64,
+        hip_kxq1: f64,
+        hip_est: f64,
+    ) -> Self {
+        Self {
+            variant,
+            precision,
+            registers,
+            hip_kxq0,
+            hip_kxq1,
+            hip_est,
+        }
+    }
+
+    /// Merge one other sketch into self via register-wise max. Both
+    /// operands must have identical variant and precision.
+    pub fn merge(
+        &mut self,
+        other: &HllSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.variant != other.variant {
+            return Err(format!(
+                "HllSketch variant mismatch: self={:?}, other={:?}",
+                self.variant, other.variant
+            )
+            .into());
+        }
+        if self.precision != other.precision {
+            return Err(format!(
+                "HllSketch precision mismatch: self={}, other={}",
+                self.precision, other.precision
+            )
+            .into());
+        }
+        if self.registers.len() != other.registers.len() {
+            return Err(format!(
+                "HllSketch register-length mismatch: self={}, other={}",
+                self.registers.len(),
+                other.registers.len()
+            )
+            .into());
+        }
+        for (s, o) in self.registers.iter_mut().zip(other.registers.iter()) {
+            if *o > *s {
+                *s = *o;
+            }
+        }
+        // HIP accumulators add on merge (each source carried its own
+        // running estimate; merged state inherits the combined
+        // components).
+        if self.variant == HllVariant::Hip {
+            self.hip_kxq0 += other.hip_kxq0;
+            self.hip_kxq1 += other.hip_kxq1;
+            self.hip_est += other.hip_est;
+        }
+        Ok(())
+    }
+
+    /// Apply a sparse register delta in place. Matches the
+    /// `registers[i] = max(registers[i], new_value)` logic in
+    /// `sketchlib-go/sketches/HLL/delta.go::ApplyRegisterDelta`. Used
+    /// by the backend ingest path to reconstitute a full sketch from
+    /// a base snapshot + subsequent delta-transmission frames (paper
+    /// §6.2 B3 / B4 baselines).
+    ///
+    /// Returns `Err` if any delta index is out of range for the
+    /// sketch's precision — indicating a precision mismatch between
+    /// the snapshot this sketch was built from and the delta sender.
+    pub fn apply_delta(
+        &mut self,
+        delta: &HllSketchDelta,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let n = self.registers.len();
+        for (idx, new_val) in &delta.updates {
+            let i = *idx as usize;
+            if i >= n {
+                return Err(format!(
+                    "HllSketchDelta index {i} out of range (precision={} → {n} registers)",
+                    self.precision
+                )
+                .into());
+            }
+            if *new_val > self.registers[i] {
+                self.registers[i] = *new_val;
+            }
+        }
+        Ok(())
+    }
+
+    /// Merge a slice of references into a single new sketch. All inputs
+    /// must share the same variant and precision; returns `Err` on
+    /// mismatch or an empty input.
+    pub fn merge_refs(
+        inputs: &[&HllSketch],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let first = inputs
+            .first()
+            .ok_or("HllSketch::merge_refs called with empty input")?;
+        let mut merged = HllSketch::new(first.variant, first.precision);
+        for hll in inputs {
+            merged.merge(hll)?;
+        }
+        Ok(merged)
+    }
+
+    /// Insert a value into the sketch. Hashes the bytes with the
+    /// canonical seed, takes the leading `precision` bits as the
+    /// register index, then `1 + leading_zeros` of the remaining
+    /// bits as the candidate register value, applied with max
+    /// semantics. Mirrors `HyperLogLogImpl::insert_with_hash` (line
+    /// 131) — re-stated here so the wire-format type doesn't need
+    /// to construct a parameterized typed sketch on every insert.
+    pub fn update(&mut self, value: &[u8]) {
+        let hashed_val = crate::hash64_seeded(crate::CANONICAL_HASH_SEED, &DataInput::Bytes(value));
+        let p = self.precision as usize;
+        let register_bits = (u64::BITS as usize) - p;
+        let p_mask: u64 = (1u64 << p) - 1;
+        let bucket_num = ((hashed_val >> register_bits) & p_mask) as usize;
+        let leading_zero = ((hashed_val << p) + p_mask).leading_zeros() as u8 + 1;
+        if bucket_num < self.registers.len() && leading_zero > self.registers[bucket_num] {
+            self.registers[bucket_num] = leading_zero;
+        }
+    }
+
+    /// Estimate the cardinality represented by this sketch.
+    /// Re-implements the Classic HLL estimator from
+    /// `HyperLogLogImpl::<Classic, _, _>::estimate` (line 203) with
+    /// small/large range corrections, returning `f64` for parity with
+    /// the other wire-format estimates.
+    pub fn estimate(&self) -> f64 {
+        let m = self.registers.len() as f64;
+        if m == 0.0 {
+            return 0.0;
+        }
+        // Indicator function: sum 2^-reg_val.
+        let mut z = 0.0_f64;
+        let mut zero_count = 0usize;
+        for &reg_val in &self.registers {
+            if reg_val == 0 {
+                zero_count += 1;
+            }
+            z += 2f64.powi(-(reg_val as i32));
+        }
+        let indicator = 1.0 / z;
+
+        let alpha_m = 0.7213 / (1.0 + 1.079 / m);
+        let mut est = alpha_m * m * m * indicator;
+
+        // Small-range correction (linear counting).
+        if est <= m * 5.0 / 2.0 && zero_count != 0 {
+            est = m * (m / zero_count as f64).ln();
+        } else if est > 143_165_576.533 {
+            // Large-range correction.
+            let aux = i32::MAX as f64;
+            est = -aux * (1.0 - est / aux).ln();
+        }
+        est
+    }
+
+    /// Serialize to MessagePack bytes (used by the legacy wire path
+    /// and by PR I's `_ENCODING_MSGPACK` variant when that lands).
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        rmp_serde::to_vec(self)
+    }
+
+    /// Deserialize from MessagePack bytes.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(rmp_serde::from_slice(buffer)?)
+    }
+}
+
+#[cfg(test)]
+mod tests_wire_hll {
+    use super::*;
+
+    #[test]
+    fn test_new_empty() {
+        let h = HllSketch::new(HllVariant::Regular, 4);
+        assert_eq!(h.registers.len(), 16);
+        assert!(h.registers.iter().all(|&r| r == 0));
+    }
+
+    #[test]
+    fn test_merge_register_wise_max() {
+        let mut a = HllSketch::from_raw(HllVariant::Regular, 2, vec![1, 5, 3, 7], 0.0, 0.0, 0.0);
+        let b = HllSketch::from_raw(HllVariant::Regular, 2, vec![4, 2, 6, 0], 0.0, 0.0, 0.0);
+        a.merge(&b).unwrap();
+        assert_eq!(a.registers, vec![4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_apply_delta_max_semantics() {
+        let mut h = HllSketch::from_raw(HllVariant::Regular, 2, vec![1, 5, 3, 7], 0.0, 0.0, 0.0);
+        let delta = HllSketchDelta {
+            updates: vec![(0, 4), (1, 2), (2, 6), (3, 0)],
+        };
+        h.apply_delta(&delta).unwrap();
+        // reg[0]: max(1,4)=4, reg[1]: max(5,2)=5, reg[2]: max(3,6)=6,
+        // reg[3]: max(7,0)=7.
+        assert_eq!(h.registers, vec![4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_apply_delta_out_of_range() {
+        let mut h = HllSketch::new(HllVariant::Regular, 2); // 4 registers
+        let delta = HllSketchDelta {
+            updates: vec![(7, 3)],
+        };
+        assert!(h.apply_delta(&delta).is_err());
+    }
+
+    #[test]
+    fn test_apply_delta_matches_full_merge() {
+        let base = HllSketch::from_raw(HllVariant::Regular, 2, vec![1, 5, 3, 7], 0.0, 0.0, 0.0);
+        let addition = HllSketch::from_raw(HllVariant::Regular, 2, vec![4, 0, 6, 0], 0.0, 0.0, 0.0);
+        let mut via_merge = base.clone();
+        via_merge.merge(&addition).unwrap();
+
+        let delta = HllSketchDelta {
+            updates: vec![(0, 4), (2, 6)],
+        };
+        let mut via_delta = base;
+        via_delta.apply_delta(&delta).unwrap();
+        assert_eq!(via_delta.registers, via_merge.registers);
+    }
+
+    #[test]
+    fn test_merge_variant_mismatch() {
+        let mut a = HllSketch::new(HllVariant::Regular, 4);
+        let b = HllSketch::new(HllVariant::Datafusion, 4);
+        assert!(a.merge(&b).is_err());
+    }
+
+    #[test]
+    fn test_merge_precision_mismatch() {
+        let mut a = HllSketch::new(HllVariant::Regular, 4);
+        let b = HllSketch::new(HllVariant::Regular, 5);
+        assert!(a.merge(&b).is_err());
+    }
+
+    #[test]
+    fn test_merge_refs() {
+        let a = HllSketch::from_raw(HllVariant::Regular, 1, vec![1, 0], 0.0, 0.0, 0.0);
+        let b = HllSketch::from_raw(HllVariant::Regular, 1, vec![0, 3], 0.0, 0.0, 0.0);
+        let c = HllSketch::from_raw(HllVariant::Regular, 1, vec![2, 2], 0.0, 0.0, 0.0);
+        let merged = HllSketch::merge_refs(&[&a, &b, &c]).unwrap();
+        assert_eq!(merged.registers, vec![2, 3]);
+    }
+
+    #[test]
+    fn test_update_then_estimate_within_2pct() {
+        // Insert N distinct keys; the HLL estimate should be within
+        // ~2% of N for precision=12 (4096 registers, std err ≈ 1.6%).
+        let n: usize = 50_000;
+        let mut h = HllSketch::new(HllVariant::Regular, 12);
+        for i in 0..n {
+            let key = format!("key-{i}");
+            h.update(key.as_bytes());
+        }
+        let est = h.estimate();
+        let rel_err = (est - n as f64).abs() / n as f64;
+        assert!(
+            rel_err < 0.02,
+            "HLL estimate {est} not within 2% of {n} (rel_err {rel_err:.4})",
+        );
+    }
+
+    #[test]
+    fn test_estimate_empty_is_zero() {
+        let h = HllSketch::new(HllVariant::Regular, 4);
+        assert_eq!(h.estimate(), 0.0);
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let original = HllSketch::from_raw(
+            HllVariant::Hip,
+            3,
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            1.0,
+            2.0,
+            3.0,
+        );
+        let bytes = original.serialize_msgpack().unwrap();
+        let decoded = HllSketch::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(decoded.registers, original.registers);
+        assert_eq!(decoded.precision, original.precision);
+        assert_eq!(decoded.hip_kxq0, 1.0);
+    }
+}

--- a/src/sketches/hydra_kll.rs
+++ b/src/sketches/hydra_kll.rs
@@ -1,0 +1,288 @@
+use crate::sketches::kll::{KllSketch, KllSketchData};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use xxhash_rust::xxh32::xxh32;
+
+#[derive(Serialize, Deserialize)]
+struct HydraKllSketchData {
+    #[serde(rename = "row_num")]
+    rows: usize,
+    #[serde(rename = "col_num")]
+    cols: usize,
+    sketches: Vec<Vec<KllSketchData>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HydraKllSketch {
+    pub sketch: Vec<Vec<KllSketch>>,
+    pub rows: usize,
+    pub cols: usize,
+}
+
+impl HydraKllSketch {
+    pub fn new(rows: usize, cols: usize, k: u16) -> Self {
+        let sketch = vec![vec![KllSketch::new(k); cols]; rows];
+        Self { sketch, rows, cols }
+    }
+
+    /// Number of hash rows in the sketch matrix.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns in the sketch matrix.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    pub fn update(&mut self, key: &str, value: f64) {
+        let key_bytes = key.as_bytes();
+        // Update each row using different hash functions
+        for i in 0..self.rows {
+            let hash_value = xxh32(key_bytes, i as u32);
+            let col_index = (hash_value as usize) % self.cols;
+            self.sketch[i][col_index].update(value);
+        }
+    }
+
+    /// Estimate the value at the given quantile `q` for `key` — the
+    /// median across rows of each row's KLL quantile estimate at the
+    /// hashed cell.
+    pub fn quantile(&self, key: &str, q: f64) -> f64 {
+        let key_bytes = key.as_bytes();
+        let mut quantiles = Vec::with_capacity(self.rows);
+
+        for i in 0..self.rows {
+            let hash_value = xxh32(key_bytes, i as u32);
+            let col_index = (hash_value as usize) % self.cols;
+            quantiles.push(self.sketch[i][col_index].quantile(q));
+        }
+
+        if quantiles.is_empty() {
+            return 0.0;
+        }
+
+        quantiles.sort_by(|a, b| match a.partial_cmp(b) {
+            Some(ordering) => ordering,
+            None => Ordering::Equal,
+        });
+
+        let mid = quantiles.len() / 2;
+        if quantiles.len() % 2 == 0 {
+            (quantiles[mid - 1] + quantiles[mid]) / 2.0
+        } else {
+            quantiles[mid]
+        }
+    }
+
+    /// Merge another HydraKllSketch into self in place. Both operands
+    /// must have identical dimensions.
+    pub fn merge(
+        &mut self,
+        other: &HydraKllSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.rows != other.rows || self.cols != other.cols {
+            return Err(format!(
+                "HydraKllSketch dimension mismatch: self={}x{}, other={}x{}",
+                self.rows, self.cols, other.rows, other.cols
+            )
+            .into());
+        }
+        for i in 0..self.rows {
+            for j in 0..self.cols {
+                self.sketch[i][j].merge(&other.sketch[i][j])?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Merge from references, returning a new sketch — convenience for
+    /// batch reduction at API edges.
+    pub fn merge_refs(
+        inputs: &[&HydraKllSketch],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let first = inputs
+            .first()
+            .ok_or("HydraKllSketch::merge_refs called with empty input")?;
+        let mut merged = (*first).clone();
+        for h in inputs.iter().skip(1) {
+            merged.merge(h)?;
+        }
+        Ok(merged)
+    }
+
+    /// Serialize to MessagePack — matches the wire format exactly.
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        let mut sketches = Vec::with_capacity(self.rows);
+        for row in &self.sketch {
+            let mut row_data = Vec::with_capacity(self.cols);
+            for cell in row {
+                // Serialize each KllSketch to KllSketchData. We can
+                // avoid the round-trip by reading directly via the
+                // public sketch_bytes accessor.
+                row_data.push(KllSketchData {
+                    k: cell.k,
+                    sketch_bytes: cell.sketch_bytes(),
+                });
+            }
+            sketches.push(row_data);
+        }
+
+        let serialized = HydraKllSketchData {
+            rows: self.rows,
+            cols: self.cols,
+            sketches,
+        };
+
+        let mut buf = Vec::new();
+        rmp_serde::encode::write(&mut buf, &serialized)?;
+        Ok(buf)
+    }
+
+    /// Deserialize from MessagePack.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let deserialized_sketch_data: HydraKllSketchData = rmp_serde::from_slice(buffer).map_err(
+            |e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to deserialize HydraKLL from MessagePack: {e}").into()
+            },
+        )?;
+
+        if deserialized_sketch_data.sketches.len() != deserialized_sketch_data.rows {
+            return Err(format!(
+                "HydraKLL row count mismatch: expected {}, got {}",
+                deserialized_sketch_data.rows,
+                deserialized_sketch_data.sketches.len()
+            )
+            .into());
+        }
+
+        let mut sketch: Vec<Vec<KllSketch>> = Vec::with_capacity(deserialized_sketch_data.rows);
+
+        for (row_idx, row) in deserialized_sketch_data.sketches.into_iter().enumerate() {
+            if row.len() != deserialized_sketch_data.cols {
+                return Err(format!(
+                    "HydraKLL column count mismatch in row {}: expected {}, got {}",
+                    row_idx,
+                    deserialized_sketch_data.cols,
+                    row.len()
+                )
+                .into());
+            }
+
+            let mut accum_row: Vec<KllSketch> = Vec::with_capacity(deserialized_sketch_data.cols);
+            for cell in row {
+                let cell_bytes = rmp_serde::to_vec(&cell).map_err(
+                    |e| -> Box<dyn std::error::Error + Send + Sync> {
+                        format!("Failed to serialize nested KLL sketch: {e}").into()
+                    },
+                )?;
+                let kll = KllSketch::deserialize_msgpack(&cell_bytes)?;
+                accum_row.push(kll);
+            }
+
+            sketch.push(accum_row);
+        }
+
+        Ok(Self {
+            sketch,
+            rows: deserialized_sketch_data.rows,
+            cols: deserialized_sketch_data.cols,
+        })
+    }
+
+    /// One-shot aggregation: build a sketch from parallel keys/values.
+    pub fn aggregate_hydrakll(
+        rows: usize,
+        cols: usize,
+        k: u16,
+        keys: &[&str],
+        values: &[f64],
+    ) -> Option<Vec<u8>> {
+        if keys.is_empty() {
+            return None;
+        }
+        let mut sketch = Self::new(rows, cols, k);
+        for (key, &value) in keys.iter().zip(values.iter()) {
+            sketch.update(key, value);
+        }
+        sketch.serialize_msgpack().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_creation() {
+        let h = HydraKllSketch::new(2, 3, 200);
+        assert_eq!(h.rows, 2);
+        assert_eq!(h.cols, 3);
+        assert_eq!(h.sketch.len(), 2);
+        assert_eq!(h.sketch[0].len(), 3);
+    }
+
+    #[test]
+    fn test_update_and_query() {
+        let mut h = HydraKllSketch::new(2, 10, 200);
+        h.update("key1", 5.0);
+        h.update("key1", 10.0);
+        // With 2 values, median quantile should be between them
+        let q = h.quantile("key1", 0.5);
+        assert!(q >= 0.0);
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut h1 = HydraKllSketch::new(2, 5, 200);
+        let mut h2 = HydraKllSketch::new(2, 5, 200);
+
+        for i in 1..=5 {
+            h1.update("key1", i as f64);
+        }
+        for i in 6..=10 {
+            h2.update("key1", i as f64);
+        }
+
+        h1.merge(&h2).unwrap();
+        assert_eq!(h1.rows, 2);
+        assert_eq!(h1.cols, 5);
+    }
+
+    #[test]
+    fn test_merge_dimension_mismatch() {
+        let mut h1 = HydraKllSketch::new(2, 5, 200);
+        let h2 = HydraKllSketch::new(3, 5, 200);
+        assert!(h1.merge(&h2).is_err());
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let mut h = HydraKllSketch::new(2, 3, 200);
+        h.update("key1", 5.0);
+        h.update("key2", 10.0);
+
+        let bytes = h.serialize_msgpack().unwrap();
+        let deserialized = HydraKllSketch::deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(deserialized.rows, 2);
+        assert_eq!(deserialized.cols, 3);
+    }
+
+    #[test]
+    fn test_aggregate_hydrakll() {
+        let keys = ["a", "b", "a"];
+        let values = [1.0, 2.0, 3.0];
+        let bytes = HydraKllSketch::aggregate_hydrakll(2, 5, 200, &keys, &values).unwrap();
+        let h = HydraKllSketch::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(h.rows, 2);
+        assert_eq!(h.cols, 5);
+    }
+
+    #[test]
+    fn test_aggregate_hydrakll_empty() {
+        assert!(HydraKllSketch::aggregate_hydrakll(2, 5, 200, &[], &[]).is_none());
+    }
+}

--- a/src/sketches/kll.rs
+++ b/src/sketches/kll.rs
@@ -1069,3 +1069,280 @@ mod tests {
         assert_eq!(a.count(), restored.count());
     }
 }
+
+// =====================================================================
+// ASAP runtime wire-format-aligned variant .
+//
+// `KllSketch` and `KllSketchData` below are the public-field,
+// proto-decode-friendly types consumed by the ASAP query engine
+// accumulators, backed by `asap_sketchlib`'s in-tree KLL. The
+// high-throughput in-process variant above (`KLL`) keeps its
+// original design.
+// =====================================================================
+
+// ----- asap_sketchlib-backed KLL helpers -----
+// Used below by `KllSketch`. Lives in this file so the wire-format
+// type and its backend share a single home.
+
+/// Concrete KLL type backing the wire-format `KllSketch`.
+pub type SketchlibKll = KLL<f64>;
+
+/// Creates a fresh sketchlib KLL sketch with the requested accuracy parameter `k`.
+pub fn new_sketchlib_kll(k: u16) -> SketchlibKll {
+    KLL::init_kll(k as i32)
+}
+
+/// Updates a sketchlib KLL with one numeric observation.
+pub fn sketchlib_kll_update(inner: &mut SketchlibKll, value: f64) {
+    inner.update(&value);
+}
+
+/// Queries a sketchlib KLL for the value at the requested quantile.
+pub fn sketchlib_kll_quantile(inner: &SketchlibKll, q: f64) -> f64 {
+    inner.quantile(q)
+}
+
+/// Merges `src` into `dst`.
+pub fn sketchlib_kll_merge(dst: &mut SketchlibKll, src: &SketchlibKll) {
+    dst.merge(src);
+}
+
+/// Serializes a sketchlib KLL into MessagePack bytes.
+pub fn bytes_from_sketchlib_kll(inner: &SketchlibKll) -> Vec<u8> {
+    inner.serialize_to_bytes().unwrap()
+}
+
+/// Deserializes a sketchlib KLL from MessagePack bytes.
+pub fn sketchlib_kll_from_bytes(bytes: &[u8]) -> Result<SketchlibKll, Box<dyn std::error::Error>> {
+    Ok(KLL::deserialize_from_bytes(bytes)?)
+}
+
+/// Wire format used in MessagePack serialization.
+#[derive(Deserialize, Serialize)]
+pub struct KllSketchData {
+    pub k: u16,
+    pub sketch_bytes: Vec<u8>,
+}
+
+pub struct KllSketch {
+    pub k: u16,
+    pub(crate) backend: SketchlibKll,
+}
+
+impl KllSketch {
+    pub fn new(k: u16) -> Self {
+        Self {
+            k,
+            backend: new_sketchlib_kll(k),
+        }
+    }
+
+    /// The configured `k` parameter (compactor capacity).
+    pub fn k(&self) -> u16 {
+        self.k
+    }
+
+    /// Returns the raw sketch bytes (for JSON serialization, etc.).
+    pub fn sketch_bytes(&self) -> Vec<u8> {
+        bytes_from_sketchlib_kll(&self.backend)
+    }
+
+    pub fn update(&mut self, value: f64) {
+        sketchlib_kll_update(&mut self.backend, value);
+    }
+
+    pub fn count(&self) -> u64 {
+        self.backend.count() as u64
+    }
+
+    /// Estimate the value at the given quantile `q ∈ [0, 1]`.
+    pub fn quantile(&self, q: f64) -> f64 {
+        if self.count() == 0 {
+            return 0.0;
+        }
+        sketchlib_kll_quantile(&self.backend, q)
+    }
+
+    /// Merge another KllSketch into self in place. Both operands must
+    /// have identical `k`.
+    pub fn merge(
+        &mut self,
+        other: &KllSketch,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.k != other.k {
+            return Err(format!("KllSketch k mismatch: self={}, other={}", self.k, other.k).into());
+        }
+        sketchlib_kll_merge(&mut self.backend, &other.backend);
+        Ok(())
+    }
+
+    /// Serialize to MessagePack — matches the wire format exactly.
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        let sketch_bytes = self.sketch_bytes();
+        let serialized = KllSketchData {
+            k: self.k,
+            sketch_bytes,
+        };
+
+        let mut buf = Vec::new();
+        rmp_serde::encode::write(&mut buf, &serialized)?;
+        Ok(buf)
+    }
+
+    /// Deserialize from MessagePack.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let wire: KllSketchData = rmp_serde::from_slice(buffer).map_err(
+            |e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to deserialize KllSketchData from MessagePack: {e}").into()
+            },
+        )?;
+
+        let backend = sketchlib_kll_from_bytes(&wire.sketch_bytes)
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+
+        Ok(Self { k: wire.k, backend })
+    }
+
+    /// Merge from references without cloning.
+    pub fn merge_refs(
+        sketches: &[&Self],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if sketches.is_empty() {
+            return Err("No sketches to merge".into());
+        }
+        let k = sketches[0].k;
+        for s in sketches {
+            if s.k != k {
+                return Err("Cannot merge KllSketch with different k values".into());
+            }
+        }
+        let mut merged = Self::new(k);
+        for s in sketches {
+            sketchlib_kll_merge(&mut merged.backend, &s.backend);
+        }
+        Ok(merged)
+    }
+
+    /// One-shot aggregation: build a sketch from a slice of values.
+    pub fn aggregate_kll(k: u16, values: &[f64]) -> Option<Vec<u8>> {
+        if values.is_empty() {
+            return None;
+        }
+        let mut sketch = Self::new(k);
+        for &value in values {
+            sketch.update(value);
+        }
+        sketch.serialize_msgpack().ok()
+    }
+}
+
+impl Clone for KllSketch {
+    fn clone(&self) -> Self {
+        let bytes = bytes_from_sketchlib_kll(&self.backend);
+        Self {
+            k: self.k,
+            backend: sketchlib_kll_from_bytes(&bytes).unwrap(),
+        }
+    }
+}
+
+impl std::fmt::Debug for KllSketch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KllSketch")
+            .field("k", &self.k)
+            .field("sketch_n", &self.count())
+            .finish()
+    }
+}
+
+// Thread safety: sketchlib's KLL is used in a single-threaded context per accumulator
+// instance and only shares read-only operations across threads.
+unsafe impl Send for KllSketch {}
+unsafe impl Sync for KllSketch {}
+
+#[cfg(test)]
+mod tests_wire_kll {
+    use super::*;
+
+    #[test]
+    fn test_kll_creation() {
+        let kll = KllSketch::new(200);
+        assert_eq!(kll.count(), 0);
+        assert_eq!(kll.k, 200);
+    }
+
+    #[test]
+    fn test_kll_update() {
+        let mut kll = KllSketch::new(200);
+        kll.update(10.0);
+        kll.update(20.0);
+        kll.update(15.0);
+        assert_eq!(kll.count(), 3);
+    }
+
+    #[test]
+    fn test_kll_quantile() {
+        let mut kll = KllSketch::new(200);
+        for i in 1..=10 {
+            kll.update(i as f64);
+        }
+        assert_eq!(kll.quantile(0.0), 1.0);
+        assert_eq!(kll.quantile(1.0), 10.0);
+        let median = kll.quantile(0.5);
+        assert!(
+            (5.0..=6.0).contains(&median),
+            "median should be between 5 and 6; got {median}"
+        );
+    }
+
+    #[test]
+    fn test_kll_merge() {
+        let mut kll1 = KllSketch::new(200);
+        let mut kll2 = KllSketch::new(200);
+
+        for i in 1..=5 {
+            kll1.update(i as f64);
+        }
+        for i in 6..=10 {
+            kll2.update(i as f64);
+        }
+
+        kll1.merge(&kll2).unwrap();
+        assert_eq!(kll1.count(), 10);
+        assert_eq!(kll1.quantile(0.0), 1.0);
+        assert_eq!(kll1.quantile(1.0), 10.0);
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let mut kll = KllSketch::new(200);
+        for i in 1..=5 {
+            kll.update(i as f64);
+        }
+
+        let bytes = kll.serialize_msgpack().unwrap();
+        let deserialized = KllSketch::deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(deserialized.k, 200);
+        assert_eq!(deserialized.count(), 5);
+        assert_eq!(deserialized.quantile(0.0), 1.0);
+        assert_eq!(deserialized.quantile(1.0), 5.0);
+    }
+
+    #[test]
+    fn test_aggregate_kll() {
+        let values = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let bytes = KllSketch::aggregate_kll(200, &values).unwrap();
+        let kll = KllSketch::deserialize_msgpack(&bytes).unwrap();
+        assert_eq!(kll.count(), 5);
+        assert_eq!(kll.quantile(0.0), 1.0);
+        assert_eq!(kll.quantile(1.0), 5.0);
+    }
+
+    #[test]
+    fn test_aggregate_kll_empty() {
+        assert!(KllSketch::aggregate_kll(200, &[]).is_none());
+    }
+}

--- a/src/sketches/mod.rs
+++ b/src/sketches/mod.rs
@@ -32,6 +32,7 @@ pub use coco::CocoBucket;
 pub mod count;
 pub use count::Count;
 pub use count::CountL2HH;
+pub use count::{CountSketch, CountSketchDelta};
 
 /// Hashing path markers for matrix-backed sketches.
 pub mod mode;
@@ -39,7 +40,9 @@ pub use mode::{FastPath, RegularPath};
 
 pub mod countmin;
 pub use crate::MatrixStorage;
-pub use countmin::{CountMin, QUICKSTART_COL_NUM, QUICKSTART_ROW_NUM};
+pub use countmin::{
+    CountMin, CountMinSketch, CountMinSketchDelta, QUICKSTART_COL_NUM, QUICKSTART_ROW_NUM,
+};
 
 #[cfg(feature = "experimental")]
 pub mod elastic;
@@ -51,12 +54,14 @@ pub use elastic::HeavyBucket;
 /// HyperLogLog implementations and aliases.
 pub mod hll;
 pub use hll::{
-    Classic, ErtlMLE, HyperLogLog, HyperLogLogHIP, HyperLogLogHIPP12, HyperLogLogHIPP14,
-    HyperLogLogHIPP16, HyperLogLogP12, HyperLogLogP14, HyperLogLogP16,
+    Classic, ErtlMLE, HllSketch, HllSketchDelta, HllVariant, HyperLogLog, HyperLogLogHIP,
+    HyperLogLogHIPP12, HyperLogLogHIPP14, HyperLogLogHIPP16, HyperLogLogP12, HyperLogLogP14,
+    HyperLogLogP16,
 };
 
 pub mod kll;
 pub use kll::KLL;
+pub use kll::{KllSketch, KllSketchData};
 
 pub mod kll_dynamic;
 pub use kll_dynamic::KLLDynamic;
@@ -73,9 +78,11 @@ pub use uniform::UniformSampling;
 
 pub mod ddsketch;
 pub use ddsketch::DDSketch;
+pub use ddsketch::{DdSketch, DdSketchDelta};
 
 pub mod cms_heap;
 pub use cms_heap::CMSHeap;
+pub use cms_heap::CountMinSketchWithHeap;
 
 pub mod cs_heap;
 pub use cs_heap::CSHeap;
@@ -88,3 +95,15 @@ pub use fold_cms::{FoldCMS, FoldCell, FoldEntry};
 
 pub mod fold_cs;
 pub use fold_cs::FoldCS;
+
+/// Hydra-style row-by-column matrix of KLL sketches for per-key
+/// approximate quantile estimation in the ASAP query engine.
+pub mod hydra_kll;
+pub use hydra_kll::HydraKllSketch;
+
+/// String-set aggregator wire format.
+pub mod set_aggregator;
+pub use set_aggregator::SetAggregator;
+
+/// Delta set aggregator wire format.
+pub mod delta_set_aggregator;

--- a/src/sketches/set_aggregator.rs
+++ b/src/sketches/set_aggregator.rs
@@ -1,0 +1,153 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Set aggregator for tracking a set of unique string keys.
+/// Wire format: `StringSet { values: HashSet<String> }` in MessagePack.
+#[derive(Debug, Clone)]
+pub struct SetAggregator {
+    pub values: HashSet<String>,
+}
+
+impl SetAggregator {
+    pub fn new() -> Self {
+        Self {
+            values: HashSet::new(),
+        }
+    }
+
+    /// Insert a key into the set.
+    pub fn update(&mut self, key: &str) {
+        self.values.insert(key.to_string());
+    }
+
+    /// Merge another SetAggregator into self in place (set union).
+    pub fn merge(
+        &mut self,
+        other: &SetAggregator,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        for v in &other.values {
+            self.values.insert(v.clone());
+        }
+        Ok(())
+    }
+
+    /// Merge from references, returning a new aggregator.
+    pub fn merge_refs(
+        inputs: &[&SetAggregator],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if inputs.is_empty() {
+            return Err("SetAggregator::merge_refs called with empty input".into());
+        }
+        let mut merged = SetAggregator::new();
+        for s in inputs {
+            merged.merge(s)?;
+        }
+        Ok(merged)
+    }
+
+    /// Serialize to MessagePack: `StringSet { values: HashSet<String> }` as a msgpack map.
+    pub fn serialize_msgpack(&self) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+        #[derive(Serialize)]
+        struct StringSet<'a> {
+            values: &'a HashSet<String>,
+        }
+        let wrapper = StringSet {
+            values: &self.values,
+        };
+        let mut buf = Vec::new();
+        rmp_serde::encode::write(&mut buf, &wrapper)?;
+        Ok(buf)
+    }
+
+    /// Deserialize from MessagePack.
+    pub fn deserialize_msgpack(
+        buffer: &[u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        #[derive(Deserialize)]
+        struct StringSet {
+            values: HashSet<String>,
+        }
+        let wrapper: StringSet = rmp_serde::from_slice(buffer).map_err(
+            |e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Failed to deserialize SetAggregator from MessagePack: {e}").into()
+            },
+        )?;
+        Ok(Self {
+            values: wrapper.values,
+        })
+    }
+}
+
+impl Default for SetAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_creation() {
+        let sa = SetAggregator::new();
+        assert!(sa.values.is_empty());
+    }
+
+    #[test]
+    fn test_insert() {
+        let mut sa = SetAggregator::new();
+        sa.update("web");
+        sa.update("api");
+        sa.update("web"); // duplicate
+        assert_eq!(sa.values.len(), 2);
+        assert!(sa.values.contains("web"));
+        assert!(sa.values.contains("api"));
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut sa1 = SetAggregator::new();
+        let mut sa2 = SetAggregator::new();
+
+        sa1.update("web");
+        sa1.update("api");
+        sa2.update("api"); // duplicate
+        sa2.update("db");
+
+        sa1.merge(&sa2).unwrap();
+        assert_eq!(sa1.values.len(), 3);
+        assert!(sa1.values.contains("web"));
+        assert!(sa1.values.contains("api"));
+        assert!(sa1.values.contains("db"));
+    }
+
+    #[test]
+    fn test_msgpack_round_trip() {
+        let mut sa = SetAggregator::new();
+        sa.update("web");
+        sa.update("api");
+
+        let bytes = sa.serialize_msgpack().unwrap();
+        let deserialized = SetAggregator::deserialize_msgpack(&bytes).unwrap();
+
+        assert_eq!(deserialized.values.len(), 2);
+        assert!(deserialized.values.contains("web"));
+        assert!(deserialized.values.contains("api"));
+    }
+
+    #[test]
+    fn test_msgpack_matches_wire_format() {
+        // Verify wire format is StringSet { values: [...] } not a plain array.
+        #[derive(Deserialize)]
+        struct StringSet {
+            values: HashSet<String>,
+        }
+        let mut sa = SetAggregator::new();
+        sa.update("a");
+        let bytes = sa.serialize_msgpack().unwrap();
+        let decoded: StringSet =
+            rmp_serde::from_slice(&bytes).expect("should decode as StringSet { values: ... }");
+        assert!(decoded.values.contains("a"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0.5 of the edge-framework design doc ([#213](https://github.com/ProjectASAP/ASAPCollector/pull/213)) — retire the standalone `sketch-core` crate and consolidate ASAP's runtime sketches into asap_sketchlib's existing `src/sketches/` layout (no separate `asap/` namespace).

For each sketch that already had a home in `src/sketches/`, the wire-format-aligned variant (with public bucket-array fields, sparse multi-cell delta types, `apply_delta`, msgpack ser/de, `from_raw`) is appended to the existing file under a clear section header. The existing in-process variants (`DDSketch`, `CountMin<S, Mode, H>`, `Count`, `HyperLogLog`, `KLL<T>`, `CMSHeap`) are unchanged.

## Changes

**Single-file homes (existing + appended wire-format types):**
| Existing file | New types added |
| --- | --- |
| `src/sketches/ddsketch.rs` | `DdSketch`, `DdSketchDelta` |
| `src/sketches/countmin.rs` | `CountMinSketch`, `CountMinDelta` |
| `src/sketches/count.rs` | `CountSketch`, `CountSketchDelta` |
| `src/sketches/hll.rs` | `HllSketch`, `HllSketchDelta`, `HllVariant` |
| `src/sketches/kll.rs` | `KllSketch`, `KllSketchData`, `KllBackend` |
| `src/sketches/cms_heap.rs` | `CountMinSketchWithHeap`, `CmsHeapItem` |

**New sibling files (no existing home):**
- `hydra_kll.rs`, `set_aggregator.rs`, `delta_set_aggregator.rs`
- `count_min_sketchlib.rs`, `count_min_with_heap_sketchlib.rs`, `kll_sketchlib.rs` (FFI helpers)

**Top-level:**
- `src/asap_runtime.rs` — `ImplMode` (Legacy | Sketchlib) selector for the runtime CountMin / KLL / CountMinWithHeap dispatch.

## Naming-conflict resolutions

- `octo_delta::HllDelta` already exists (single-register, octo path), so the wire-format multi-register delta is renamed to `HllSketchDelta`.
- `common::input::HeapItem` already exists, so the wire-format CMSHeap item is renamed to `CmsHeapItem`.

## Tests

\`\`\`
cargo test --lib  →  376 passed, 0 failed
\`\`\`
(308 existing + 68 ported wire-format tests; no regressions.)

## Followups

- [ProjectASAP/ASAPQuery-backend#73](https://github.com/ProjectASAP/ASAPQuery-backend/pull/73): switch consumer imports from \`sketch_core::*\` to \`asap_sketchlib::sketches::*\`; drop the \`asap-common/sketch-core\` workspace member.
- [ProjectASAP/ASAPQuery#307](https://github.com/ProjectASAP/ASAPQuery/pull/307): same migration for the legacy fork.