### PR TITLE
refactor: align wire format + apply_delta to sketchlib-go

### DIFF
--- a/src/sketches/count.rs
+++ b/src/sketches/count.rs
@@ -1407,17 +1407,20 @@ mod tests {
 
 // (de-duplicated) use serde::{Deserialize, Serialize};
 
+/// Default Top-K capacity. Mirrors sketchlib-go `TOPK_SIZE = 100`.
+pub const COUNT_SKETCH_TOPK_CAPACITY: usize = 100;
+
 /// Sparse delta between two consecutive CountSketch snapshots —
 /// the input shape for [`CountSketch::apply_delta`]. Mirrors the
 /// `CountSketchDelta` proto in
-/// `sketchlib-go/proto/countsketch/countsketch.proto` (packed
-/// encoding only — the deprecated `cells_legacy` path + the
-/// non-delta `topk` / `hh_keys` top-K carrier aren't modeled here).
+/// `sketchlib-go/proto/countsketch/countsketch.proto` and the native
+/// Go `Delta` in `sketchlib-go/sketches/CountSketch/delta.go`.
 ///
 /// Cells apply additively: `matrix[row][col] += d_count` for each
-/// `(row, col, d_count)` triple. Top-K on the delta path is a
-/// separate follow-up (CS top-K is non-linear; merging deltas
-/// would require re-querying the merged matrix).
+/// `(row, col, d_count)` triple. Per-row L2 norm deltas apply
+/// additively. Heavy-hitter candidate keys (`hh_keys`) are queried
+/// against the post-merge matrix and used to rebuild the receiver's
+/// Top-K heap.
 #[derive(Debug, Clone, Default)]
 pub struct CountSketchDelta {
     pub rows: u32,
@@ -1425,13 +1428,18 @@ pub struct CountSketchDelta {
     /// `(row, col, d_count)` cell updates, additive on the CS matrix.
     pub cells: Vec<(u32, u32, i64)>,
     /// Per-row L2 norm deltas. Additive, one scalar per row of the
-    /// base sketch. Kept on the delta surface for downstream
-    /// error-accounting; `apply_delta` itself ignores L2.
+    /// base sketch.
     pub l2: Vec<f64>,
+    /// Heavy-hitter candidate keys forwarded by the upstream
+    /// Space-Saving tracker. The receiver re-queries the merged CS
+    /// matrix for each key and updates its Top-K heap with the
+    /// resulting estimate. Mirrors Go's `Delta.HHKeys`.
+    pub hh_keys: Vec<String>,
 }
 
 /// Minimal Count Sketch state — a flat `rows × cols` matrix of signed
-/// counts. Element-wise mergeable (sum over aligned cells).
+/// counts. Element-wise mergeable (sum over aligned cells). Mirrors
+/// sketchlib-go's `CountSketch.Count`/`L2`/`TopK` triple.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CountSketch {
     #[serde(rename = "row_num")]
@@ -1441,6 +1449,16 @@ pub struct CountSketch {
     /// Row-major matrix of signed counts. `matrix[r][c]` is the value of
     /// hash row `r`, column `c`.
     pub matrix: Vec<Vec<f64>>,
+    /// Per-row L2 norm; sketchlib-go `CountSketch.L2`. Additive on
+    /// merge / apply_delta. Defaults to zero-shape on legacy payloads.
+    #[serde(default)]
+    pub l2: Vec<f64>,
+    /// Top-K heavy hitters as `(key, count)` pairs, capped at
+    /// [`COUNT_SKETCH_TOPK_CAPACITY`]. Order is not guaranteed (heap
+    /// shape is not preserved on the wire). Mirrors Go's
+    /// `CountSketch.TopK` slot. Defaults to empty on legacy payloads.
+    #[serde(default)]
+    pub topk: Vec<(String, f64)>,
 }
 
 impl CountSketch {
@@ -1450,23 +1468,67 @@ impl CountSketch {
             rows,
             cols,
             matrix: vec![vec![0.0; cols]; rows],
+            l2: vec![0.0; rows],
+            topk: Vec::new(),
         }
     }
 
     /// Construct from a pre-built matrix (used by the modified-OTLP
-    /// proto-decode path).
+    /// proto-decode path). `l2` and `topk` are zero-initialised;
+    /// callers that need non-zero auxiliary state should use the
+    /// msgpack/proto path.
     pub fn from_legacy_matrix(matrix: Vec<Vec<f64>>, rows: usize, cols: usize) -> Self {
         debug_assert_eq!(matrix.len(), rows, "row count mismatch");
         debug_assert!(
             matrix.iter().all(|r| r.len() == cols),
             "column count mismatch in at least one row"
         );
-        Self { rows, cols, matrix }
+        Self {
+            rows,
+            cols,
+            matrix,
+            l2: vec![0.0; rows],
+            topk: Vec::new(),
+        }
     }
 
     /// Borrow the inner matrix.
     pub fn sketch(&self) -> &Vec<Vec<f64>> {
         &self.matrix
+    }
+
+    /// Update the in-memory Top-K heap with `(key, count)`. Keeps the
+    /// heap bounded by [`COUNT_SKETCH_TOPK_CAPACITY`]; on overflow,
+    /// drops the smallest-count entry. If `key` is already present,
+    /// the new count replaces the old (max semantics). Used by
+    /// `apply_delta` to rebuild Top-K from `hh_keys`.
+    fn topk_update(&mut self, key: &str, count: f64) {
+        if let Some(slot) = self.topk.iter_mut().find(|(k, _)| k == key) {
+            if count > slot.1 {
+                slot.1 = count;
+            }
+            return;
+        }
+        if self.topk.len() < COUNT_SKETCH_TOPK_CAPACITY {
+            self.topk.push((key.to_owned(), count));
+            return;
+        }
+        // Capacity hit: replace the minimum if `count` exceeds it.
+        if let Some((min_idx, min_count)) = self
+            .topk
+            .iter()
+            .enumerate()
+            .min_by(|a, b| {
+                a.1.1
+                    .partial_cmp(&b.1.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, e)| (i, e.1))
+        {
+            if count > min_count {
+                self.topk[min_idx] = (key.to_owned(), count);
+            }
+        }
     }
 
     /// Insert a single weighted observation. Each row uses an independent
@@ -1487,7 +1549,14 @@ impl CountSketch {
             // Sign derived from the high bit, matching the in-process
             // Count Sketch implementation above.
             let sign = if (h >> 63) & 1 == 1 { 1.0 } else { -1.0 };
-            self.matrix[r][col] += sign * value;
+            let prev = self.matrix[r][col];
+            let curr = prev + sign * value;
+            self.matrix[r][col] = curr;
+            // Maintain L2 incrementally: `L2[r] += curr^2 - prev^2`.
+            // Mirrors sketchlib-go's `s.L2[r] += (curr*curr) - (prev*prev)`.
+            if r < self.l2.len() {
+                self.l2[r] += curr * curr - prev * prev;
+            }
         }
     }
 
@@ -1515,7 +1584,10 @@ impl CountSketch {
     }
 
     /// Merge one other sketch into self via element-wise addition. Both
-    /// operands must have identical dimensions.
+    /// operands must have identical dimensions. Mirrors sketchlib-go
+    /// `CountSketch.Merge`: count matrix and L2 add element-wise; the
+    /// other sketch's TopK entries are re-queried against the merged
+    /// matrix to update self's TopK with globally-accurate estimates.
     pub fn merge(
         &mut self,
         other: &CountSketch,
@@ -1527,37 +1599,65 @@ impl CountSketch {
             )
             .into());
         }
+        // 1. Element-wise matrix + L2 merge.
         for r in 0..self.rows {
             for c in 0..self.cols {
                 self.matrix[r][c] += other.matrix[r][c];
             }
+            if r < self.l2.len() && r < other.l2.len() {
+                self.l2[r] += other.l2[r];
+            }
+        }
+        // 2. Re-estimate other's TopK keys against the merged matrix
+        // and feed them into self.topk. Mirrors Go's
+        // `for _, item := range o.TopK.Heap { ... }` loop.
+        for (key, _) in other.topk.clone() {
+            let est = self.estimate(&key);
+            self.topk_update(&key, est);
         }
         Ok(())
     }
 
     /// Apply a sparse delta in place. Matches the `ApplyDelta`
     /// semantics in `sketchlib-go/sketches/CountSketch/delta.go`:
-    /// `matrix[row][col] += d_count` for each cell in the delta.
-    /// Returns `Err` if any `(row, col)` is out of range — indicating
-    /// a dimension mismatch between the snapshot this sketch was
-    /// built from and the delta sender.
+    ///   * each `(row, col, d_count)` triple updates the count matrix
+    ///     additively (`matrix[r][c] += d_count`);
+    ///   * per-row L2 deltas apply additively to `self.l2`;
+    ///   * each `hh_key` is re-queried against the post-update matrix
+    ///     and pushed into the receiver's TopK with the merged-estimate
+    ///     count.
+    ///
+    /// **Out-of-range cells are silently skipped** to match Go's
+    /// `if r >= target.Rows || col >= target.Cols { continue }`
+    /// (delta.go lines 75-77). The `Result` return is kept for
+    /// signature stability; this implementation never returns `Err`.
     pub fn apply_delta(
         &mut self,
         delta: &CountSketchDelta,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // 1. Cell additions, silently skipping out-of-range entries.
         for (row, col, d_count) in &delta.cells {
             let r = *row as usize;
             let c = *col as usize;
             if r >= self.rows || c >= self.cols {
-                return Err(format!(
-                    "CountSketchDelta cell ({r},{c}) out of range (matrix={}x{})",
-                    self.rows, self.cols
-                )
-                .into());
+                continue;
             }
             // `d_count` is signed on the wire; CS counts are signed
             // too (can go negative under adversarial keys).
             self.matrix[r][c] += *d_count as f64;
+        }
+        // 2. Per-row L2 deltas (silently skip rows beyond `self.rows`).
+        for (r, v) in delta.l2.iter().enumerate() {
+            if r < self.rows && r < self.l2.len() {
+                self.l2[r] += *v;
+            }
+        }
+        // 3. Heavy-hitter rebuild from `hh_keys`. Re-estimate against
+        // the freshly-updated matrix and push into TopK with the
+        // merged count.
+        for key in &delta.hh_keys {
+            let est = self.estimate(key);
+            self.topk_update(key, est);
         }
         Ok(())
     }
@@ -1651,6 +1751,7 @@ mod tests_wire_count {
                 (1, 1, -15), // 5 - 15 = -10
             ],
             l2: vec![],
+            hh_keys: vec![],
         };
         cs.apply_delta(&delta).unwrap();
         assert_eq!(
@@ -1672,6 +1773,7 @@ mod tests_wire_count {
             cols: 2,
             cells: vec![(0, 0, 10), (1, 1, 20)],
             l2: vec![],
+            hh_keys: vec![],
         };
         let mut via_delta = base;
         via_delta.apply_delta(&delta).unwrap();
@@ -1679,15 +1781,75 @@ mod tests_wire_count {
     }
 
     #[test]
-    fn test_apply_delta_out_of_range() {
-        let mut cs = CountSketch::new(2, 3);
+    fn test_apply_delta_out_of_range_silently_skipped() {
+        // Aligns with sketchlib-go's
+        // `if r >= target.Rows || col >= target.Cols { continue }`.
+        // Out-of-range cells are dropped; in-range cells in the same
+        // delta still apply.
+        let mut cs = CountSketch::from_legacy_matrix(vec![vec![0.0; 3]; 2], 2, 3);
         let delta = CountSketchDelta {
             rows: 2,
             cols: 3,
-            cells: vec![(2, 0, 1)], // row 2 out of range for 2-row matrix
+            cells: vec![(2, 0, 99), (1, 5, 99), (1, 1, 7)],
             l2: vec![],
+            hh_keys: vec![],
         };
-        assert!(cs.apply_delta(&delta).is_err());
+        cs.apply_delta(&delta).expect("silent-skip never errors");
+        assert_eq!(cs.matrix[1][1], 7.0);
+        assert_eq!(cs.matrix[0][0], 0.0);
+    }
+
+    #[test]
+    fn test_apply_delta_updates_l2() {
+        let mut cs = CountSketch::from_legacy_matrix(vec![vec![1.0, -2.0], vec![3.0, -4.0]], 2, 2);
+        cs.l2 = vec![5.0, 25.0];
+        let delta = CountSketchDelta {
+            rows: 2,
+            cols: 2,
+            cells: vec![],
+            l2: vec![10.0, 20.0],
+            hh_keys: vec![],
+        };
+        cs.apply_delta(&delta).unwrap();
+        assert_eq!(cs.l2, vec![15.0, 45.0]);
+    }
+
+    #[test]
+    fn test_apply_delta_rebuilds_topk_from_hh_keys() {
+        // Construct a sketch with a known matrix; insert a value via
+        // `update` so the matrix has a coherent shape, then send a
+        // delta that only carries an `hh_keys` entry. The receiver
+        // should requery the merged matrix and populate `topk`.
+        let mut cs = CountSketch::new(3, 16);
+        cs.update("alpha", 5.0);
+        cs.update("beta", 3.0);
+        let delta = CountSketchDelta {
+            rows: 3,
+            cols: 16,
+            cells: vec![],
+            l2: vec![],
+            hh_keys: vec!["alpha".to_string(), "beta".to_string()],
+        };
+        cs.apply_delta(&delta).unwrap();
+        assert_eq!(cs.topk.len(), 2);
+        let alpha_count = cs
+            .topk
+            .iter()
+            .find(|(k, _)| k == "alpha")
+            .map(|(_, v)| *v)
+            .unwrap();
+        let beta_count = cs
+            .topk
+            .iter()
+            .find(|(k, _)| k == "beta")
+            .map(|(_, v)| *v)
+            .unwrap();
+        // Alpha was inserted with weight 5; the median estimate
+        // should be close to 5 modulo signed-counter cancellation.
+        assert!(
+            alpha_count > beta_count,
+            "alpha={alpha_count} beta={beta_count}"
+        );
     }
 
     #[test]

--- a/src/sketches/countmin.rs
+++ b/src/sketches/countmin.rs
@@ -1035,6 +1035,9 @@ pub fn sketchlib_cms_query(inner: &SketchlibCms, key: &str) -> f64 {
     inner.estimate(&input)
 }
 
+/// Internal msgpack-wire shape. `#[serde(default)]` on the Go-side
+/// auxiliary matrices/norms keeps deserialization back-compatible
+/// with older payloads that only carried `sketch`/`rows`/`cols`.
 #[derive(Serialize, Deserialize)]
 struct WireFormat {
     sketch: Vec<Vec<f64>>,
@@ -1042,34 +1045,76 @@ struct WireFormat {
     rows: usize,
     #[serde(rename = "col_num")]
     cols: usize,
+    #[serde(default)]
+    sum: Vec<Vec<f64>>,
+    #[serde(default)]
+    sum2: Vec<Vec<f64>>,
+    #[serde(default)]
+    l1: Vec<f64>,
+    #[serde(default)]
+    l2: Vec<f64>,
 }
 
 /// Sparse delta between two consecutive CountMinSketch snapshots —
 /// the input shape for [`CountMinSketch::apply_delta`]. Mirrors the
 /// `CountMinSketchDelta` proto in
-/// `sketchlib-go/proto/countminsketch/countminsketch.proto` (packed
-/// encoding only).
+/// `sketchlib-go/proto/countminsketch/countminsketch.proto` and the
+/// native Go `Delta` in `sketchlib-go/sketches/CountMinSketch/delta.go`.
 ///
-/// Cells apply additively: `matrix[row][col] += d_count`. Per-row
-/// L1 and L2 norm deltas are carried for downstream error-accounting
-/// but are not consumed by `apply_delta` itself.
+/// Cells apply additively: `matrix[row][col] += d_count`. To match
+/// sketchlib-go's `ApplyDelta`, the same `d_count` is also added to
+/// the `sum` and `sum2` matrices on apply (assumes unit-weight
+/// streams — see `delta.go` lines 70-72). Per-row `l1`/`l2` norm
+/// deltas are full per-row arrays, additive on the corresponding
+/// matrices' L1/L2 fields.
+///
+/// Note: Go's `Delta` does NOT carry separate `Sum`/`Sum2` cell
+/// arrays. The receiver reconstructs Sum/Sum2 from the DCount
+/// arrays, which is exact for unit-weight streams (the only stream
+/// shape sketchlib-go's apply path supports).
 #[derive(Debug, Clone, Default)]
 pub struct CountMinSketchDelta {
     pub rows: u32,
     pub cols: u32,
+    /// `(row, col, d_count)` updates. Applied to `count`, `sum`, and
+    /// `sum2` matrices simultaneously.
     pub cells: Vec<(u32, u32, i64)>,
+    /// Per-row L1 norm deltas, length = `rows` (when present).
     pub l1: Vec<f64>,
+    /// Per-row L2 norm deltas, length = `rows` (when present).
     pub l2: Vec<f64>,
 }
 
 /// Provides approximate frequency counts with error bounds.
 /// The msgpack wire format is the contract between sketch producers and
 /// the query engine consumer.
+///
+/// In addition to the count matrix (held inside the high-throughput
+/// `backend`), this type carries the auxiliary `sum` and `sum2`
+/// matrices and per-row `l1`/`l2` norms produced by sketchlib-go's
+/// `CountMinSketch.Add` family. These are populated via `update`
+/// and merged/applied in lockstep with the count matrix; older
+/// (Rust-only) payloads with these arrays absent deserialize fine
+/// thanks to `#[serde(default)]` on `WireFormat`.
 #[derive(Debug, Clone)]
 pub struct CountMinSketch {
     pub rows: usize,
     pub cols: usize,
     pub(crate) backend: SketchlibCms,
+    /// Per-cell weighted sum matrix; `sum[r][c] += weight` per insert.
+    /// Mirrors sketchlib-go `CountMinSketch.Sum`.
+    pub sum: Vec<Vec<f64>>,
+    /// Per-cell sum-of-weights matrix; `sum2[r][c] += weight` per insert.
+    /// (Note: matches Go's `sum2Row[c] += many`, which is **linear**
+    /// in `many`, not `many*many`. Equal to `sum` and `count` for
+    /// unit-weight streams.)
+    pub sum2: Vec<Vec<f64>>,
+    /// Per-row L1 norm; sketchlib-go `CountMinSketch.L1`.
+    pub l1: Vec<f64>,
+    /// Per-row L2 norm (sum of squared counts), sketchlib-go
+    /// `CountMinSketch.L2`. Updated incrementally via the
+    /// `curr*curr - prev*prev` rule.
+    pub l2: Vec<f64>,
 }
 
 impl CountMinSketch {
@@ -1078,6 +1123,10 @@ impl CountMinSketch {
             rows,
             cols,
             backend: new_sketchlib_cms(rows, cols),
+            sum: vec![vec![0.0; cols]; rows],
+            sum2: vec![vec![0.0; cols]; rows],
+            l1: vec![0.0; rows],
+            l2: vec![0.0; rows],
         }
     }
 
@@ -1097,16 +1146,62 @@ impl CountMinSketch {
     }
 
     /// Construct from a `Vec<Vec<f64>>` matrix (used by deserialization and query engine).
+    /// `sum`/`sum2`/`l1`/`l2` are zero-initialised; callers that need
+    /// non-zero auxiliary state should use the msgpack/proto path.
     pub fn from_legacy_matrix(sketch: Vec<Vec<f64>>, rows: usize, cols: usize) -> Self {
         Self {
             rows,
             cols,
             backend: sketchlib_cms_from_matrix(rows, cols, &sketch),
+            sum: vec![vec![0.0; cols]; rows],
+            sum2: vec![vec![0.0; cols]; rows],
+            l1: vec![0.0; rows],
+            l2: vec![0.0; rows],
         }
     }
 
+    /// Insert a weighted observation. Mirrors sketchlib-go's
+    /// `FastInsertWeightWithHashValue` semantics: per row r, locate
+    /// the column via the backend's hash, then update count, sum,
+    /// sum2, L1, and L2 in lockstep. `sum2` is **linear** in `value`
+    /// (matches Go's `sum2Row[c] += many`), not quadratic.
     pub fn update(&mut self, key: &str, value: f64) {
+        if value == 0.0 || self.rows == 0 || self.cols == 0 {
+            // Still propagate the count update even when our auxiliary
+            // tracking can't run (zero-weight is silently ignored by
+            // the backend either way; preserve that behaviour).
+            sketchlib_cms_update(&mut self.backend, key, value);
+            return;
+        }
+        // Snapshot the count matrix, perform the backend update, then
+        // diff to find the (one) cell each row touched. The backend's
+        // hash layout is opaque from this side; the diff is the
+        // simplest correctness-preserving way to mirror Go's
+        // per-cell Sum/Sum2/L1/L2 update without re-implementing the
+        // hash. Cost: O(rows * cols) per insert. Acceptable: the
+        // wire-format CountMinSketch is the ingest-side type, not a
+        // hot inner loop; the high-throughput
+        // `CountMin<S, M, H>` (above this section) is untouched.
+        let prev_matrix = matrix_from_sketchlib_cms(&self.backend);
         sketchlib_cms_update(&mut self.backend, key, value);
+        let new_matrix = matrix_from_sketchlib_cms(&self.backend);
+        for r in 0..self.rows {
+            let prev_row = &prev_matrix[r];
+            let new_row = &new_matrix[r];
+            for c in 0..self.cols {
+                let prev = prev_row[c];
+                let curr = new_row[c];
+                if (curr - prev).abs() <= f64::EPSILON * curr.abs().max(1.0) {
+                    continue;
+                }
+                self.sum[r][c] += value;
+                self.sum2[r][c] += value;
+                self.l2[r] += curr * curr - prev * prev;
+                self.l1[r] += value;
+                // CountMin chooses exactly one cell per row.
+                break;
+            }
+        }
     }
 
     /// Estimate the frequency of `key` (CountMin point query).
@@ -1115,7 +1210,9 @@ impl CountMinSketch {
     }
 
     /// Merge another CountMinSketch into self in place. Both operands
-    /// must have identical dimensions.
+    /// must have identical dimensions. Mirrors sketchlib-go
+    /// `CountMinSketch.Merge`: count, sum, sum2, L1, L2 all add
+    /// element-wise.
     pub fn merge(
         &mut self,
         other: &CountMinSketch,
@@ -1128,6 +1225,29 @@ impl CountMinSketch {
             .into());
         }
         self.backend.merge(&other.backend);
+        for r in 0..self.rows {
+            // Sum / Sum2 may have been left at default zero by callers
+            // that constructed via `from_legacy_matrix`; defensive
+            // length check tolerates that case.
+            if r < other.sum.len() && r < self.sum.len() {
+                let cols = self.sum[r].len().min(other.sum[r].len());
+                for c in 0..cols {
+                    self.sum[r][c] += other.sum[r][c];
+                }
+            }
+            if r < other.sum2.len() && r < self.sum2.len() {
+                let cols = self.sum2[r].len().min(other.sum2[r].len());
+                for c in 0..cols {
+                    self.sum2[r][c] += other.sum2[r][c];
+                }
+            }
+            if r < other.l1.len() && r < self.l1.len() {
+                self.l1[r] += other.l1[r];
+            }
+            if r < other.l2.len() && r < self.l2.len() {
+                self.l2[r] += other.l2[r];
+            }
+        }
         Ok(())
     }
 
@@ -1159,33 +1279,53 @@ impl CountMinSketch {
 
     /// Apply a sparse delta in place. Matches the `ApplyDelta`
     /// semantics in `sketchlib-go/sketches/CountMinSketch/delta.go`:
-    /// `matrix[row][col] += d_count` for each cell in the delta.
+    /// for each `(row, col, d_count)` cell, `count[r][c] += d_count`
+    /// and additionally `sum[r][c] += d_count`, `sum2[r][c] += d_count`
+    /// (Go's unit-weight reconstruction — see `delta.go::ApplyDelta`
+    /// lines 70-72). Per-row L1 and L2 deltas are applied additively
+    /// to the corresponding norm arrays.
     ///
-    /// The FFI handle is opaque, so we snapshot the matrix, apply
-    /// cell updates, and rebuild the backend. The rebuild is
-    /// O(rows × cols) per delta and is acceptable for ingest-side
-    /// reconstitution — no delta should fire more than once per
-    /// window (10s–300s in the paper's B3 / B4 configs).
+    /// **Out-of-range cells are silently skipped** to match Go's
+    /// `if r >= rows || col >= cols { continue }` (delta.go line 67-69).
+    /// In-range cells in the same delta still apply.
+    ///
+    /// The FFI handle is opaque, so we snapshot the count matrix,
+    /// apply cell updates, and rebuild the backend. The rebuild is
+    /// O(rows × cols) per delta — acceptable for ingest-side
+    /// reconstitution (deltas fire at most once per window: 10s–300s
+    /// in the paper's B3 / B4 configs). The Result return is kept
+    /// for signature stability; this implementation never returns
+    /// `Err`.
     pub fn apply_delta(
         &mut self,
         delta: &CountMinSketchDelta,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        for (row, col, _) in &delta.cells {
+        let mut matrix = self.sketch();
+        for (row, col, d_count) in &delta.cells {
             let r = *row as usize;
             let c = *col as usize;
             if r >= self.rows || c >= self.cols {
-                return Err(format!(
-                    "CountMinSketchDelta cell ({r},{c}) out of range (matrix={}x{})",
-                    self.rows, self.cols
-                )
-                .into());
+                // Silent-skip per sketchlib-go semantics.
+                continue;
             }
-        }
-        let mut matrix = self.sketch();
-        for (row, col, d_count) in &delta.cells {
-            matrix[*row as usize][*col as usize] += *d_count as f64;
+            let dc = *d_count as f64;
+            matrix[r][c] += dc;
+            self.sum[r][c] += dc;
+            self.sum2[r][c] += dc;
         }
         self.backend = sketchlib_cms_from_matrix(self.rows, self.cols, &matrix);
+        // Per-row norm deltas; mirror Go's bounds check
+        // (`if r < target.Rows`).
+        for (r, v) in delta.l1.iter().enumerate() {
+            if r < self.rows {
+                self.l1[r] += *v;
+            }
+        }
+        for (r, v) in delta.l2.iter().enumerate() {
+            if r < self.rows {
+                self.l2[r] += *v;
+            }
+        }
         Ok(())
     }
 
@@ -1196,6 +1336,10 @@ impl CountMinSketch {
             sketch,
             rows: self.rows,
             cols: self.cols,
+            sum: self.sum.clone(),
+            sum2: self.sum2.clone(),
+            l1: self.l1.clone(),
+            l2: self.l2.clone(),
         };
 
         let mut buf = Vec::new();
@@ -1203,7 +1347,9 @@ impl CountMinSketch {
         Ok(buf)
     }
 
-    /// Deserialize from MessagePack.
+    /// Deserialize from MessagePack. `sum`/`sum2`/`l1`/`l2` default to
+    /// zero-shape vectors when absent (back-compat for older payloads
+    /// produced before these auxiliary fields were added).
     pub fn deserialize_msgpack(
         buffer: &[u8],
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -1214,11 +1360,38 @@ impl CountMinSketch {
         )?;
 
         let backend = sketchlib_cms_from_matrix(wire.rows, wire.cols, &wire.sketch);
+        // Back-fill auxiliary state to the matrix shape. Older
+        // payloads without these fields land here as zero-shape
+        // vectors; resize them to the matrix dimensions so all
+        // downstream operations (merge / apply_delta) see a
+        // well-shaped state.
+        let mut sum = wire.sum;
+        let mut sum2 = wire.sum2;
+        if sum.len() != wire.rows {
+            sum = vec![vec![0.0; wire.cols]; wire.rows];
+        }
+        if sum2.len() != wire.rows {
+            sum2 = vec![vec![0.0; wire.cols]; wire.rows];
+        }
+        let l1 = if wire.l1.len() == wire.rows {
+            wire.l1
+        } else {
+            vec![0.0; wire.rows]
+        };
+        let l2 = if wire.l2.len() == wire.rows {
+            wire.l2
+        } else {
+            vec![0.0; wire.rows]
+        };
 
         Ok(Self {
             rows: wire.rows,
             cols: wire.cols,
             backend,
+            sum,
+            sum2,
+            l1,
+            l2,
         })
     }
 
@@ -1389,15 +1562,79 @@ mod tests_wire_countmin {
     }
 
     #[test]
-    fn test_apply_delta_out_of_range() {
-        let mut cms = CountMinSketch::new(2, 3);
+    fn test_apply_delta_out_of_range_silently_skipped() {
+        // Aligns with sketchlib-go's `if r >= rows || col >= cols { continue }`.
+        // Out-of-range cells are dropped; in-range cells in the same
+        // delta still apply.
+        let mut cms = CountMinSketch::from_legacy_matrix(vec![vec![0.0; 3]; 2], 2, 3);
         let delta = CountMinSketchDelta {
             rows: 2,
             cols: 3,
-            cells: vec![(5, 0, 1)],
+            cells: vec![(5, 0, 1), (1, 7, 1), (0, 1, 9)],
             l1: vec![],
             l2: vec![],
         };
-        assert!(cms.apply_delta(&delta).is_err());
+        cms.apply_delta(&delta).expect("silent-skip never errors");
+        // Only the (0, 1, 9) cell is in range; it lands at matrix[0][1].
+        let m = cms.sketch();
+        assert_eq!(m[0][1], 9.0);
+        assert_eq!(m[0][0], 0.0);
+        assert_eq!(m[1][2], 0.0);
+    }
+
+    #[test]
+    fn test_apply_delta_updates_sum_sum2() {
+        // Matches Go's CountMinSketch/delta.go::ApplyDelta:
+        // `target.Sum[r][c] += float64(c.DCount)` (and same for Sum2).
+        let mut cms = CountMinSketch::from_legacy_matrix(
+            vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
+            2,
+            3,
+        );
+        let delta = CountMinSketchDelta {
+            rows: 2,
+            cols: 3,
+            cells: vec![(0, 0, 10), (1, 2, 5)],
+            l1: vec![100.0, 50.0],
+            l2: vec![1000.0, 500.0],
+        };
+        cms.apply_delta(&delta).unwrap();
+        assert_eq!(cms.sum[0][0], 10.0);
+        assert_eq!(cms.sum[1][2], 5.0);
+        assert_eq!(cms.sum2[0][0], 10.0);
+        assert_eq!(cms.sum2[1][2], 5.0);
+        assert_eq!(cms.l1, vec![100.0, 50.0]);
+        assert_eq!(cms.l2, vec![1000.0, 500.0]);
+    }
+
+    #[test]
+    fn test_msgpack_back_compat_without_aux_fields() {
+        // Older payloads carrying only sketch/rows/cols must still
+        // deserialize. We simulate this by hand-rolling a minimal
+        // legacy WireFormat-compatible struct.
+        #[derive(Serialize)]
+        struct LegacyWire {
+            sketch: Vec<Vec<f64>>,
+            #[serde(rename = "row_num")]
+            rows: usize,
+            #[serde(rename = "col_num")]
+            cols: usize,
+        }
+        let legacy = LegacyWire {
+            sketch: vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+            rows: 2,
+            cols: 2,
+        };
+        let mut buf = Vec::new();
+        legacy
+            .serialize(&mut rmp_serde::Serializer::new(&mut buf))
+            .unwrap();
+        let cms = CountMinSketch::deserialize_msgpack(&buf).unwrap();
+        assert_eq!(cms.rows, 2);
+        assert_eq!(cms.cols, 2);
+        assert_eq!(cms.sum.len(), 2);
+        assert_eq!(cms.sum[0], vec![0.0, 0.0]);
+        assert_eq!(cms.l1, vec![0.0, 0.0]);
+        assert_eq!(cms.l2, vec![0.0, 0.0]);
     }
 }

--- a/src/sketches/ddsketch.rs
+++ b/src/sketches/ddsketch.rs
@@ -782,7 +782,12 @@ mod tests {
 pub struct DdSketchDelta {
     /// `(absolute_bucket_index, Δcount)` pairs, additive.
     pub buckets: Vec<(i32, u64)>,
-    /// Δ total count. May be negative (signed on the wire).
+    /// Δ total count. **Ignored on the apply path**: to match
+    /// `sketchlib-go/sketches/DDSketch/delta.go::ApplyDelta`, the
+    /// total count is reconstructed by summing per-bucket `Δcount`
+    /// values inside the bucket loop. Kept on the struct because the
+    /// wire `DDSketchDelta` proto still carries it (field 2); future
+    /// codecs may reuse it for cross-checks.
     pub d_count: i64,
     /// Δ sum.
     pub d_sum: f64,
@@ -910,10 +915,13 @@ impl DdSketch {
 
     /// Apply a sparse delta to this sketch in place. Matches the
     /// `ApplyDelta` logic in `sketchlib-go/sketches/DDSketch/delta.go`:
-    /// bucket counts add, total count + sum add, min can only decrease
-    /// and max can only increase. Used by the backend ingest path to
-    /// reconstitute a full sketch from a base snapshot + subsequent
-    /// delta-transmission frames (paper §6.2 B3 / B4 baselines).
+    /// bucket counts add (wrapping `u64`), total count is reconstructed
+    /// from the per-bucket `Δcount` sum (the wire-level `delta.d_count`
+    /// is ignored on apply — see `DdSketchDelta::d_count`), sum adds,
+    /// and min/max apply with min/max semantics. Used by the backend
+    /// ingest path to reconstitute a full sketch from a base snapshot
+    /// + subsequent delta-transmission frames (paper §6.2 B3 / B4
+    ///   baselines).
     pub fn apply_delta(&mut self, delta: &DdSketchDelta) {
         for (abs_idx, d_count) in &delta.buckets {
             if self.store_counts.is_empty() {
@@ -935,12 +943,14 @@ impl DdSketch {
                 self.store_counts.extend(std::iter::repeat_n(0u64, pad));
             }
             let arr_idx = (k - self.store_offset as i64) as usize;
-            self.store_counts[arr_idx] = self.store_counts[arr_idx].saturating_add(*d_count);
-        }
-        if delta.d_count >= 0 {
-            self.count = self.count.saturating_add(delta.d_count as u64);
-        } else {
-            self.count = self.count.saturating_sub((-delta.d_count) as u64);
+            // Wrapping `u64` add to match Go's
+            // `target.store.counts.AsMutSlice()[idx] += b.DCount`
+            // (Go uint64 += is wrapping by spec).
+            self.store_counts[arr_idx] = self.store_counts[arr_idx].wrapping_add(*d_count);
+            // Reconstruct total count from per-bucket DCount sum, also
+            // wrapping. `delta.d_count` is intentionally NOT used here
+            // — see field doc on `DdSketchDelta::d_count`.
+            self.count = self.count.wrapping_add(*d_count);
         }
         self.sum += delta.d_sum;
         if delta.min_changed && delta.new_min < self.min {
@@ -1105,7 +1115,11 @@ mod tests_wire_ddsketch {
         let mut base = DdSketch::from_raw(0.01, vec![1, 2, 3], -1, 6, 30.0, 1.0, 5.0);
         let delta = DdSketchDelta {
             buckets: vec![(-1, 4), (0, 8), (1, 12)],
-            d_count: 24,
+            // d_count is intentionally inconsistent with the bucket
+            // sum (4+8+12=24); apply_delta must IGNORE this value and
+            // reconstruct the count from per-bucket DCounts to match
+            // sketchlib-go's `target.count += b.DCount` semantics.
+            d_count: 999_999,
             d_sum: 120.0,
             min_changed: false,
             new_min: 0.0,
@@ -1114,10 +1128,56 @@ mod tests_wire_ddsketch {
         };
         base.apply_delta(&delta);
         assert_eq!(base.store_counts, vec![5, 10, 15]);
-        assert_eq!(base.count, 30);
+        assert_eq!(base.count, 30, "count must come from per-bucket DCount sum");
         assert_eq!(base.sum, 150.0);
         assert_eq!(base.min, 1.0);
         assert_eq!(base.max, 9.0);
+    }
+
+    #[test]
+    fn test_apply_delta_count_reconstructed_from_buckets() {
+        // d_count on the wire is ignored. Even if it's set to zero,
+        // the per-bucket DCount sum must be applied to `count`.
+        let mut base = DdSketch::from_raw(
+            0.01,
+            vec![0, 0, 0],
+            0,
+            0,
+            0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        );
+        let delta = DdSketchDelta {
+            buckets: vec![(0, 5), (1, 7), (2, 11)],
+            d_count: 0, // wrong on purpose: must be ignored
+            d_sum: 23.0,
+            min_changed: true,
+            new_min: 1.0,
+            max_changed: true,
+            new_max: 3.0,
+        };
+        base.apply_delta(&delta);
+        assert_eq!(base.store_counts, vec![5, 7, 11]);
+        assert_eq!(base.count, 23, "count = sum of per-bucket DCounts");
+    }
+
+    #[test]
+    fn test_apply_delta_bucket_overflow_wraps() {
+        // Match sketchlib-go's wrapping uint64 add. Saturating would
+        // pin to u64::MAX; wrapping rolls over to a small value.
+        let mut base = DdSketch::from_raw(0.01, vec![u64::MAX], 0, 0, 0.0, 1.0, 1.0);
+        let delta = DdSketchDelta {
+            buckets: vec![(0, 5)],
+            d_count: 0,
+            d_sum: 0.0,
+            min_changed: false,
+            new_min: 0.0,
+            max_changed: false,
+            new_max: 0.0,
+        };
+        base.apply_delta(&delta);
+        // u64::MAX + 5 wraps to 4 (since MAX = 2^64 - 1).
+        assert_eq!(base.store_counts[0], 4);
     }
 
     #[test]

--- a/src/sketches/hll.rs
+++ b/src/sketches/hll.rs
@@ -1040,9 +1040,10 @@ impl HllSketch {
     /// a base snapshot + subsequent delta-transmission frames (paper
     /// §6.2 B3 / B4 baselines).
     ///
-    /// Returns `Err` if any delta index is out of range for the
-    /// sketch's precision — indicating a precision mismatch between
-    /// the snapshot this sketch was built from and the delta sender.
+    /// Out-of-range indices are silently skipped to match Go's
+    /// `if int(u.Index) < len(regs)` guard. The `Result` return is
+    /// retained for signature stability with earlier revisions; this
+    /// implementation never returns `Err`.
     pub fn apply_delta(
         &mut self,
         delta: &HllSketchDelta,
@@ -1051,11 +1052,11 @@ impl HllSketch {
         for (idx, new_val) in &delta.updates {
             let i = *idx as usize;
             if i >= n {
-                return Err(format!(
-                    "HllSketchDelta index {i} out of range (precision={} → {n} registers)",
-                    self.precision
-                )
-                .into());
+                // Silent-skip: aligns with sketchlib-go semantics; an
+                // out-of-range index indicates a precision mismatch
+                // between the snapshot and the delta sender, but the
+                // remaining in-range updates are still valid.
+                continue;
             }
             if *new_val > self.registers[i] {
                 self.registers[i] = *new_val;
@@ -1180,12 +1181,16 @@ mod tests_wire_hll {
     }
 
     #[test]
-    fn test_apply_delta_out_of_range() {
+    fn test_apply_delta_out_of_range_silently_skipped() {
+        // Aligns with sketchlib-go's `if int(u.Index) < len(regs)`
+        // pre-guard: out-of-range indices are dropped, in-range
+        // updates still apply.
         let mut h = HllSketch::new(HllVariant::Regular, 2); // 4 registers
         let delta = HllSketchDelta {
-            updates: vec![(7, 3)],
+            updates: vec![(7, 3), (1, 4)],
         };
-        assert!(h.apply_delta(&delta).is_err());
+        h.apply_delta(&delta).expect("silent-skip never errors");
+        assert_eq!(h.registers, vec![0, 4, 0, 0]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bring the wire-format `DdSketch` / `CountMinSketch` / `CountSketch` / `HllSketch` types into byte-and-semantic parity with sketchlib-go's canonical producer side. The Rust runtime is the consumer; semantic divergence on `apply_delta` was producing wrong query results when reconstituting sketches from base + delta frames.

Per-sketch:

- **DDSketch** — `apply_delta` reconstructs `count` from per-bucket DCount sum (was using the wire's `d_count` field, which is now ignored); bucket overflow uses `wrapping_add` (was saturating).
- **CountMin** — added `sum`, `sum2`, `l1`, `l2` fields mirroring sketchlib-go; `update`/`merge`/`apply_delta` maintain them per Go's exact semantics (`sum2` is linear in weight, not quadratic — Go-quirk preserved); out-of-range cells silent-skip.
- **CountSketch** — added `l2` and `topk` (Vec<(String, f64)>, cap 100); `apply_delta` re-queries each `hh_keys` against the merged matrix to rebuild TopK; L2 maintained incrementally on `update`; out-of-range cells silent-skip.
- **HLL** — `apply_delta` silent-skips out-of-range register indices.

`#[serde(default)]` on the new CountMin / CountSketch fields keeps legacy msgpack payloads deserializing fine.

## Test plan
- [x] `cargo test --lib` — 384 passed (+6 new).
- [x] `cargo clippy --all-features --tests -- -D warnings` — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.
- [x] `cargo fmt` — clean.

## Out of scope
- Proto-schema changes (`asap_otel_proto::sketchlib::v1::CountSketchDelta` doesn't carry `hh_keys` yet — coordinated separately).
- High-throughput in-process types (`DDSketch`, `CountMin<S, M, H>`, `Count`, `HyperLogLog*`, `KLL<T>`, `CMSHeap`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)