### PR TITLE
fix(countsketch): port HashSpec / derive_index / derive_sign from sketchlib-go

### DIFF
--- a/src/common/hashspec.rs
+++ b/src/common/hashspec.rs
@@ -1,0 +1,307 @@
+//! Cross-language hash layer mirroring `sketchlib-go::common`'s
+//! `HashSpec` / `DeriveIndex` / `DeriveSign` decomposition for
+//! matrix-backed sketches (CountSketch, CountMinSketch).
+//!
+//! `sketchlib-go` and `asap_sketchlib` share three building blocks for
+//! these sketches:
+//!
+//!   1. A 20-entry seed table ([`CANONICAL_HASH_SEED_TABLE`], identical
+//!      bit-for-bit to Go's `seedList`).
+//!   2. A canonical seed index ([`CANONICAL_HASH_SEED`] = 5).
+//!   3. A single XXH3-64-with-seed call per (key, seed) pair, with the
+//!      resulting `u64` then bit-sliced into per-row column indices and
+//!      ±1 signs.
+//!
+//! This module re-exposes that pipeline as a small, byte-key API so
+//! sketches that consume keys as raw bytes (e.g. the wire-format
+//! `CountSketch::update`) can match Go's emitted matrix
+//! cell-for-cell. CountMinSketch's pending byte-parity fix will reuse
+//! the same primitives — the seed table, derive_index, and derive_sign
+//! are agnostic to whether ±1 signing is applied.
+//!
+//! # Example
+//!
+//! ```
+//! use asap_sketchlib::common::hashspec::{HashSpec, hash_with_spec, derive_index, derive_sign};
+//!
+//! let spec = HashSpec::default();             // matches Go's portableHashSpec()
+//! let key = b"flow-7";
+//! let h = hash_with_spec(&spec, key);         // single XXH3-64 with seed_list[0]
+//! let col = derive_index(&spec, 0, h, 512);   // row 0, width 512
+//! let sign = derive_sign(&spec, 0, h);        // -1 or +1
+//! assert!(col < 512);
+//! assert!(sign == -1 || sign == 1);
+//! ```
+
+use twox_hash::XxHash3_64;
+
+/// 20-entry seed table shared by all matrix-backed sketches.
+///
+/// Bit-for-bit identical to `sketchlib-go::common.seedList` — the order
+/// MUST match because `derive_index` / `derive_sign` produce byte
+/// parity only when both libraries pull the same `u64` from index `i`.
+pub const CANONICAL_HASH_SEED_TABLE: [u64; 20] = [
+    0xcafe3553,
+    0xade3415118,
+    0x8cc70208,
+    0x2f024b2b,
+    0x451a3df5,
+    0x6a09e667,
+    0xbb67ae85,
+    0x3c6ef372,
+    0xa54ff53a,
+    0x510e527f,
+    0x9b05688c,
+    0x1f83d9ab,
+    0x5be0cd19,
+    0xcbbb9d5d,
+    0x629a292a,
+    0x9159015a,
+    0x152fecd8,
+    0x67332667,
+    0x8eb44a87,
+    0xdb0c2e0d,
+];
+
+/// Default canonical-seed index used by single-hash matrix-sketch
+/// operations. Matches `sketchlib-go::common.CanonicalHashSeed` and
+/// `asap_sketchlib::common::hash::CANONICAL_HASH_SEED`.
+pub const CANONICAL_HASH_SEED: usize = 5;
+
+/// Hash configuration shared by matrix-backed sketches.
+///
+/// Mirrors `sketchlib-go::common.HashSpec` semantics: a producer
+/// records the seed table, the canonical seed index, and the seed
+/// derivation strategy so consumers can validate hash compatibility
+/// before merging.
+///
+/// `asap_sketchlib`'s wire-format CountSketch (and the upcoming CMS
+/// byte-parity fix) construct a `HashSpec::default()` and feed it to
+/// [`derive_index`] / [`derive_sign`] on the hot path. The default
+/// matches Go's `portableHashSpec()`:
+///
+/// - `seed_list = CANONICAL_HASH_SEED_TABLE`
+/// - `canonical_seed_index = CANONICAL_HASH_SEED` (= 5)
+/// - `seed_derivation = SeedDerivation::Packed` — the matrix sketches
+///   used today fit in a single packed `u64` (rows × bits_per_row ≤ 64),
+///   so a single hash with `seed_list[0]` covers all rows. The
+///   `Additive` variant is reserved for the per-row-hash fallback used
+///   by larger matrices and is not yet exercised by the wire path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HashSpec {
+    /// Full seed table, length must be > 0.
+    pub seed_list: Vec<u64>,
+    /// Index into `seed_list` for the canonical (single-hash) seed.
+    pub canonical_seed_index: usize,
+    /// Strategy for deriving per-row seeds.
+    pub seed_derivation: SeedDerivation,
+}
+
+/// Strategy for deriving per-row seeds, mirroring
+/// `sketchlib-go::common.SeedDerivation`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SeedDerivation {
+    /// All rows share `seed_list[0]`; per-row column index and sign are
+    /// extracted via bit slicing on a single `u64` hash. Used when
+    /// `rows × bits_per_row ≤ 64`.
+    Packed,
+    /// Each row r uses `seed_list[(base + r) % len]`; one
+    /// XXH3-64-with-seed call per row. Reserved for matrices that
+    /// exceed the packed budget.
+    Additive,
+}
+
+impl Default for HashSpec {
+    fn default() -> Self {
+        Self {
+            seed_list: CANONICAL_HASH_SEED_TABLE.to_vec(),
+            canonical_seed_index: CANONICAL_HASH_SEED,
+            seed_derivation: SeedDerivation::Packed,
+        }
+    }
+}
+
+impl HashSpec {
+    /// Returns the seed used for the single-hash packed path. Matches
+    /// Go's `seedList[0]` (because Go's `Hash64` calls `HashIt(0, key)`,
+    /// not `HashIt(canonical_seed_index, key)` — the canonical-seed
+    /// index governs `CanonicalHash`/`hh_keys` lookups, not the
+    /// matrix hot path). The matrix path always uses index 0,
+    /// regardless of `canonical_seed_index`.
+    #[inline]
+    pub fn matrix_seed(&self) -> u64 {
+        // Mirror Go's `common.Hash64`: `HashIt(0, key)` reads
+        // `seedList[normalizedSeedIdx(0)]` = seedList[0].
+        self.seed_list[0]
+    }
+
+    /// Returns the seed for row `r` under the additive-offset
+    /// derivation (reserved; not used by the packed wire path).
+    #[inline]
+    pub fn row_seed(&self, row: usize) -> u64 {
+        let idx = row % self.seed_list.len();
+        self.seed_list[idx]
+    }
+}
+
+/// Hashes `key` under `spec`'s matrix seed (single XXH3-64-with-seed
+/// call, mirroring Go's `common.Hash64`). Producers of byte-parity
+/// CountSketch / CMS update paths call this once per key, then invoke
+/// [`derive_index`] / [`derive_sign`] per row to populate the matrix.
+#[inline]
+pub fn hash_with_spec(spec: &HashSpec, key: &[u8]) -> u64 {
+    XxHash3_64::oneshot_with_seed(spec.matrix_seed(), key)
+}
+
+/// Returns `mask_bits` such that `(1 << mask_bits) - 1` is the column
+/// mask for `width`. Mirrors Go's `maskBitsForWidth`.
+#[inline]
+fn mask_bits_for_width(width: u32) -> u32 {
+    if width <= 1 {
+        return 1;
+    }
+    // ceil(log2(width)). Wire-path widths are power-of-two, so this
+    // collapses to `width.trailing_zeros()`.
+    let mut u = width - 1;
+    let mut bits = 0u32;
+    while u > 0 {
+        bits += 1;
+        u >>= 1;
+    }
+    bits
+}
+
+/// Derives the row-local column index from a precomputed `hash`,
+/// mirroring `sketchlib-go::common.DeriveIndex`:
+///
+/// ```text
+/// shift = row * mask_bits(width)
+/// index = (hash >> shift) & (width - 1)
+/// ```
+///
+/// `width` MUST be power-of-two (the wire-format matrix sketches
+/// enforce this on construction); other values produce a mask that
+/// does not equal `width - 1` and the caller's matrix-cell layout
+/// will diverge from Go's.
+#[inline]
+pub fn derive_index(_spec: &HashSpec, row: usize, hash: u64, width: u32) -> usize {
+    let shift = (row as u32) * mask_bits_for_width(width);
+    let mask = (width as u64).wrapping_sub(1);
+    ((hash >> shift) & mask) as usize
+}
+
+/// Derives the ±1 sign for row `row` from a precomputed `hash`,
+/// mirroring `sketchlib-go::common.DeriveSign`:
+///
+/// ```text
+/// bit  = (hash >> (63 - row)) & 1
+/// sign = bit == 1 ? +1 : -1
+/// ```
+///
+/// `row` must satisfy `row <= 63`; callers with deeper sketches must
+/// switch to the per-row hash fallback (not yet exposed here).
+#[inline]
+pub fn derive_sign(_spec: &HashSpec, row: usize, hash: u64) -> i64 {
+    debug_assert!(
+        row <= 63,
+        "derive_sign: row {row} out of range for u64 hash"
+    );
+    let bit = (hash >> (63 - row as u32)) & 1;
+    if bit == 0 { -1 } else { 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Locks the seed table to Go's `seedList`. Any drift here will
+    /// silently desync the matrix-cell layout from `sketchlib-go`'s.
+    #[test]
+    fn seed_table_matches_sketchlib_go() {
+        // Captured from `sketchlib-go::common.seedList` (hash.go:13-34).
+        let go_seed_list: [u64; 20] = [
+            0xcafe3553,
+            0xade3415118,
+            0x8cc70208,
+            0x2f024b2b,
+            0x451a3df5,
+            0x6a09e667,
+            0xbb67ae85,
+            0x3c6ef372,
+            0xa54ff53a,
+            0x510e527f,
+            0x9b05688c,
+            0x1f83d9ab,
+            0x5be0cd19,
+            0xcbbb9d5d,
+            0x629a292a,
+            0x9159015a,
+            0x152fecd8,
+            0x67332667,
+            0x8eb44a87,
+            0xdb0c2e0d,
+        ];
+        assert_eq!(CANONICAL_HASH_SEED_TABLE, go_seed_list);
+        assert_eq!(CANONICAL_HASH_SEED, 5);
+    }
+
+    /// Locks `hash_with_spec` to Go's `Hash64` for a representative
+    /// key. Captured by running `common.Hash64([]byte("projectasap"))`
+    /// in sketchlib-go (see `common/hash_test.go::TestXxh3RegressionVectors`).
+    #[test]
+    fn hash_with_spec_matches_sketchlib_go() {
+        let spec = HashSpec::default();
+        let got = hash_with_spec(&spec, b"projectasap");
+        // From sketchlib-go::common::hash_test.go: Hash64(key) = 887548862923853302.
+        assert_eq!(got, 887548862923853302);
+    }
+
+    /// derive_index slices the hash exactly the way Go's DeriveIndex
+    /// does. Sanity-check across rows and widths.
+    #[test]
+    fn derive_index_matches_go_bit_slicing() {
+        let spec = HashSpec::default();
+        // Same hash Go would compute for "projectasap" with seedList[0].
+        let h = hash_with_spec(&spec, b"projectasap");
+        // 9-bit width (512 cols) → mask 0x1ff, shift = row*9.
+        for row in 0..3 {
+            let expected = ((h >> (row as u32 * 9)) & 0x1ff) as usize;
+            assert_eq!(derive_index(&spec, row, h, 512), expected);
+        }
+        // 10-bit width (1024 cols) → mask 0x3ff, shift = row*10.
+        for row in 0..3 {
+            let expected = ((h >> (row as u32 * 10)) & 0x3ff) as usize;
+            assert_eq!(derive_index(&spec, row, h, 1024), expected);
+        }
+    }
+
+    /// derive_sign extracts the high-bit-minus-row exactly like Go.
+    #[test]
+    fn derive_sign_matches_go_high_bit() {
+        let spec = HashSpec::default();
+        let h = hash_with_spec(&spec, b"projectasap");
+        for row in 0..5 {
+            let bit = (h >> (63 - row as u32)) & 1;
+            let expected: i64 = if bit == 0 { -1 } else { 1 };
+            assert_eq!(derive_sign(&spec, row, h), expected);
+        }
+    }
+
+    #[test]
+    fn mask_bits_for_width_matches_go() {
+        assert_eq!(mask_bits_for_width(1), 1);
+        assert_eq!(mask_bits_for_width(2), 1);
+        assert_eq!(mask_bits_for_width(4), 2);
+        assert_eq!(mask_bits_for_width(512), 9);
+        assert_eq!(mask_bits_for_width(1024), 10);
+        assert_eq!(mask_bits_for_width(4096), 12);
+    }
+
+    #[test]
+    fn default_hashspec_has_packed_derivation() {
+        let spec = HashSpec::default();
+        assert_eq!(spec.seed_derivation, SeedDerivation::Packed);
+        assert_eq!(spec.canonical_seed_index, CANONICAL_HASH_SEED);
+        assert_eq!(spec.seed_list.len(), CANONICAL_HASH_SEED_TABLE.len());
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,6 +19,10 @@
 
 /// Hashing utilities and seed definitions shared across sketches.
 pub mod hash;
+/// Cross-language hash spec (`HashSpec`/`derive_index`/`derive_sign`)
+/// shared by matrix-backed sketches that need byte parity with
+/// `sketchlib-go` (CountSketch, the upcoming CMS PR, …).
+pub mod hashspec;
 pub mod heap;
 pub mod input;
 pub mod numerical;

--- a/src/sketches/countsketch.rs
+++ b/src/sketches/countsketch.rs
@@ -1249,40 +1249,62 @@ impl CountSketch {
         }
     }
 
-    /// Insert a single weighted observation. Each row uses an independent
-    /// hash seed and a sign bit to update the matrix in place — the
-    /// standard CountSketch update primitive. The wire format here uses
-    /// xxh64 with per-row seeding; this matches sketchlib-go's
-    /// `DeriveIndex`/`DeriveSign` decomposition for matrix-backed
-    /// sketches and is intended for in-process tests / ground-truth
-    /// builds, not cross-language replay.
+    /// Insert a single weighted observation. Routes the key through the
+    /// shared [`crate::common::hashspec`] pipeline so the matrix-cell
+    /// layout matches `sketchlib-go::CountSketch.UpdateString`
+    /// bit-for-bit:
+    ///
+    /// 1. `hash = Hash64(key) = XXH3-64-with-seed(seed_list[0], key)`
+    ///    (Go's `common.Hash64`, mirrored by
+    ///    [`hash_with_spec`](crate::common::hashspec::hash_with_spec))
+    /// 2. for each row `r`:
+    ///    - `col = derive_index(spec, r, hash, cols)` — Go's
+    ///      `MatrixHashType.RowHash` slice on the packed `u64`
+    ///    - `sign = derive_sign(spec, r, hash)` — Go's
+    ///      `MatrixHashType.SignForRow` high-bit-minus-row extraction
+    /// 3. `matrix[r][col] += sign * value`
+    ///
+    /// Constraints inherited from Go's Packed64 mode (the only mode
+    /// the wire-format CountSketch exercises today):
+    /// - `cols` must be a power of two; the column mask is `cols - 1`.
+    /// - `rows * (log2(cols) + 1) ≤ 64` so the packed hash holds all
+    ///   row indices and sign bits.
+    ///
+    /// Both constraints are honored by the
+    /// `asap-precompute-rs::CountSketchWrapper` defaults (3×512 → 30
+    /// bits) and by `sketchlib-go`'s
+    /// `RustDefaultRows = 3, RustDefaultCols = 4096` (39 bits).
     pub fn update(&mut self, key: &str, value: f64) {
         if self.rows == 0 || self.cols == 0 {
             return;
         }
-        let key_bytes = key.as_bytes();
+        let spec = crate::common::hashspec::HashSpec::default();
+        let hash = crate::common::hashspec::hash_with_spec(&spec, key.as_bytes());
+        let cols_u32 = self.cols as u32;
         for r in 0..self.rows {
-            let h = twox_hash::XxHash64::oneshot(r as u64, key_bytes);
-            let col = (h as usize) % self.cols;
-            // Sign derived from the high bit, matching the in-process
-            // Count Sketch implementation above.
-            let sign = if (h >> 63) & 1 == 1 { 1.0 } else { -1.0 };
+            let col = crate::common::hashspec::derive_index(&spec, r, hash, cols_u32);
+            let sign = crate::common::hashspec::derive_sign(&spec, r, hash) as f64;
             self.matrix[r][col] += sign * value;
         }
     }
 
     /// Estimate the frequency of `key` via the standard median-of-rows
-    /// CountSketch query. Returns 0 for an empty sketch.
+    /// CountSketch query. Returns 0 for an empty sketch. Mirrors
+    /// `sketchlib-go::CountSketch.QueryWithHash(QueryFrequency)`: the
+    /// per-row column index and sign are derived from the same single
+    /// hash that [`Self::update`] used, so the estimator inverts the
+    /// signed-counter projection in lockstep with the update.
     pub fn estimate(&self, key: &str) -> f64 {
         if self.rows == 0 || self.cols == 0 {
             return 0.0;
         }
-        let key_bytes = key.as_bytes();
+        let spec = crate::common::hashspec::HashSpec::default();
+        let hash = crate::common::hashspec::hash_with_spec(&spec, key.as_bytes());
+        let cols_u32 = self.cols as u32;
         let mut estimates: Vec<f64> = Vec::with_capacity(self.rows);
         for r in 0..self.rows {
-            let h = twox_hash::XxHash64::oneshot(r as u64, key_bytes);
-            let col = (h as usize) % self.cols;
-            let sign = if (h >> 63) & 1 == 1 { 1.0 } else { -1.0 };
+            let col = crate::common::hashspec::derive_index(&spec, r, hash, cols_u32);
+            let sign = crate::common::hashspec::derive_sign(&spec, r, hash) as f64;
             estimates.push(sign * self.matrix[r][col]);
         }
         estimates.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
@@ -1559,5 +1581,106 @@ mod tests_wire_count {
         assert_eq!(decoded.sketch(), original.sketch());
         assert_eq!(decoded.rows, original.rows);
         assert_eq!(decoded.cols, original.cols);
+    }
+
+    /// Cross-language byte-parity guard against `sketchlib-go`'s
+    /// `CountSketch.SerializeProtoBytes` output for the deterministic
+    /// input `goldenCsKeys()` (25 keys "k-a"..."k-e", each repeated 5×)
+    /// at dimensions `(rows=3, cols=512)`. The hex blob below was
+    /// captured from a `proto.Marshal` of the Go envelope with
+    /// `Producer` and `HashSpec` cleared (matching the
+    /// `integration/parity/golden_test.go::TestGenerateGoldenFixtures`
+    /// recipe used for DDSketch and KLL).
+    ///
+    /// Any drift in [`CountSketch::update`]'s hash → (col, sign)
+    /// derivation breaks this test cell-for-cell; that is the contract
+    /// `cross_language_parity::countsketch_byte_parity_with_go` in
+    /// ASAPCollector relies on. Closes part of
+    /// ProjectASAP/ASAPCollector#243.
+    #[test]
+    fn test_update_then_envelope_matches_sketchlib_go_bytes() {
+        use crate::proto::sketchlib::{
+            CountSketchState, CounterType, SketchEnvelope, sketch_envelope::SketchState,
+        };
+        use prost::Message;
+
+        let rows = 3usize;
+        let cols = 512usize;
+        let mut sk = CountSketch::new(rows, cols);
+        for i in 0..25 {
+            let key = format!("k-{}", (b'a' + (i % 5) as u8) as char);
+            sk.update(&key, 1.0);
+        }
+
+        // Build envelope mirroring sketchlib-go's CountSketch.SerializePortable:
+        //   counter_type = INT64, counts packed sint64 in row-major
+        //   order, l2 = per-row sum of squared cells, no TopK.
+        let mut counts_int: Vec<i64> = Vec::with_capacity(rows * cols);
+        let mut l2: Vec<f64> = Vec::with_capacity(rows);
+        for row in sk.matrix.iter().take(rows) {
+            let mut row_l2 = 0.0f64;
+            for &cell in row.iter().take(cols) {
+                counts_int.push(cell as i64);
+                row_l2 += cell * cell;
+            }
+            l2.push(row_l2);
+        }
+
+        let state = CountSketchState {
+            rows: rows as u32,
+            cols: cols as u32,
+            counter_type: CounterType::Int64 as i32,
+            counts_int,
+            counts_float: Vec::new(),
+            l2,
+            topk: None,
+        };
+        let envelope = SketchEnvelope {
+            format_version: 1,
+            producer: None,
+            hash_spec: None,
+            sketch_state: Some(SketchState::CountSketch(state)),
+        };
+        let mut got = Vec::with_capacity(envelope.encoded_len());
+        envelope.encode(&mut got).expect("prost encode");
+
+        // Byte string captured from sketchlib-go for the same
+        // (3,512) × `goldenCsKeys()` input — see
+        // `integration/parity/golden_test.go` and
+        // `cross_language_parity::countsketch_byte_parity_with_go`
+        // in ASAPCollector. 1577 bytes total: a `SketchEnvelope` proto
+        // wrapping a `CountSketchState` whose `counts_int` is a packed
+        // sint64 (zigzag) row-major matrix and `l2` is `[125.0;3]`
+        // (each row's 5 hot cells hold ±5 → l2 = 5·25 = 125).
+        const GOLDEN_HEX: &str = "08015aa40c0803108004180222800c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090000000000000a000000000000000900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000032180000000000405f400000000000405f400000000000405f40";
+        let want = decode_hex(GOLDEN_HEX);
+        assert_eq!(
+            got,
+            want,
+            "CountSketch envelope bytes diverge from sketchlib-go golden \
+             ({} bytes got vs {} bytes want)",
+            got.len(),
+            want.len(),
+        );
+    }
+
+    fn decode_hex(s: &str) -> Vec<u8> {
+        s.as_bytes()
+            .chunks(2)
+            .map(|pair| {
+                let high = hex_nibble(pair[0]);
+                let low = hex_nibble(pair[1]);
+                (high << 4) | low
+            })
+            .collect()
+    }
+
+    fn hex_nibble(c: u8) -> u8 {
+        match c {
+            b'0'..=b'9' => c - b'0',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
+            _ => panic!("non-hex byte {}", c as char),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`asap_sketchlib::CountSketch::update` was using `twox_hash::XxHash64::oneshot(r as u64, key)` per row — a different hash function and per-row seeding that produced a matrix layout completely divergent from `sketchlib-go::CountSketch.UpdateString`. As a result the cross-language byte-parity guard `cross_language_parity::countsketch_byte_parity_with_go` in ASAPCollector had to be `#[ignore]`d, blocking ProjectASAP/ASAPCollector#243.

This PR ports Go's `HashSpec` / `DeriveIndex` / `DeriveSign` decomposition into a new public module `asap_sketchlib::common::hashspec` and refactors `CountSketch::update` / `estimate` to use it. The shared module is the foundation for the upcoming CMS byte-parity PR — that PR will plug `derive_index` straight into `CountMinSketch::update` and stay scoped to the sketch-specific update loop.

### Changes

- **New module `src/common/hashspec.rs`** (`pub`):
  - `CANONICAL_HASH_SEED_TABLE: [u64; 20]` — bit-for-bit identical to Go's `seedList`, locked by a unit test.
  - `CANONICAL_HASH_SEED = 5` — matches `sketchlib-go::common.CanonicalHashSeed`.
  - `HashSpec` struct + `SeedDerivation` enum — mirrors Go's `HashSpec` semantics; default ctor matches `portableHashSpec()`.
  - `hash_with_spec(spec, key) -> u64` — single XXH3-64-with-seed call, locked to Go's regression vector (`Hash64("projectasap") = 887548862923853302`).
  - `derive_index(spec, row, hash, width) -> usize` — Go's `DeriveIndex` bit-slice. **CMS PR will reuse this as-is** (CMS does not sign-flip; only the index derivation is needed).
  - `derive_sign(spec, row, hash) -> i64` — Go's `DeriveSign` high-bit-minus-row extraction. CountSketch-specific.
- **Refactor `CountSketch::update` / `estimate`** (`src/sketches/countsketch.rs`) to call into the shared module: hash once with `hash_with_spec`, derive col + sign per row, update/query the cell. Loop structure mirrors Go's `CountSketch.insertWithMatrixHash` Packed64 path.
- **New byte-parity test** `tests_wire_count::test_update_then_envelope_matches_sketchlib_go_bytes` — builds a (3, 512) sketch, runs the `goldenCsKeys()` input (25 keys "k-a"…"k-e", each ×5), encodes a `SketchEnvelope` mirroring Go's `SerializePortable` (sint64 counts, derived L2, no Producer / HashSpec), and asserts the bytes equal a 1577-byte hex blob captured from `sketchlib-go::CountSketch.SerializeProtoBytes`. Same DDSketch / KLL guard pattern (PR #40 / #41).

### CMS reuse

The new module is `pub` and the API is documented for the CMS PR to plug in directly:

```rust
use asap_sketchlib::common::hashspec::{HashSpec, hash_with_spec, derive_index};
let spec = HashSpec::default();
let h = hash_with_spec(&spec, key);
for r in 0..rows {
    let col = derive_index(&spec, r, h, cols as u32);
    cms.matrix[r][col] += value;
}
```

CMS does not need `derive_sign` or any other CountSketch-specific helpers; the seed table + index derivation are the only shared pieces.

## Test plan

- [x] `cargo test --all` — 392 lib tests + 1 bin + 19 doctest pass.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] New test `test_update_then_envelope_matches_sketchlib_go_bytes` passes against the Go-captured golden hex.
- [x] All existing `sketches::countsketch::*` tests (53) continue to pass under the refactored hash path.
- [ ] Follow-up ASAPCollector PR un-ignores `cross_language_parity::countsketch_byte_parity_with_go`.

Closes part of ProjectASAP/ASAPCollector#243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)