### PR TITLE
perf(hash): inline fast-path matrix hash entry to restore FixedMatrix specialization

### DIFF
--- a/src/common/hash.rs
+++ b/src/common/hash.rs
@@ -255,6 +255,7 @@ pub fn hash_for_matrix(rows: usize, cols: usize, key: &DataInput) -> MatrixHashT
 
 /// Creates a fast-path hash for a matrix-backed sketch with a custom seed.
 /// Chooses a packed hash when the required bits fit in 128; otherwise uses per-row hashes.
+#[inline(always)]
 pub fn hash_for_matrix_seeded(
     seed_idx: usize,
     rows: usize,
@@ -312,6 +313,7 @@ pub fn hash_for_matrix_generic<H: SketchHasher>(
 }
 
 /// Generic version of hash_for_matrix_seeded that uses a custom hasher.
+#[inline(always)]
 pub fn hash_for_matrix_seeded_generic<H: SketchHasher>(
     seed_idx: usize,
     rows: usize,


### PR DESCRIPTION
## Summary

Two `#[inline(always)]` annotations on `hash_for_matrix_seeded` and `hash_for_matrix_seeded_generic` ([src/common/hash.rs](src/common/hash.rs)). No behavior change, no API change.

## Why

In non-monolithic / non-PGO builds, LLVM's inliner refuses to inline `hash_for_matrix_seeded_generic` because its return type (`MatrixHashType` enum carrying a `SmallVec` field + drop glue) puts it over the cost-model threshold. That call boundary erases compile-time `rows` / `cols` literals coming from `FixedMatrix` call sites — `rows` / `cols` degrade into runtime ABI arguments, `hash_mode_for_matrix(rows, cols)` can't fold to `Packed64` / `Packed128` / `Rows`, the returned enum has to be materialized at runtime, and the caller must runtime-discriminate on the tag. The `Rows` arm carries a row-count-indexed loop with `cmp`/`jb` bailouts.

Forcing inline collapses the chain:
- `rows = 5`, `cols = 2048` propagate as literals
- `mode` folds to `Packed64`
- other match arms get dead-coded out
- SROA flattens the enum
- the resulting hot loop is a fully unrolled 5-row block (5 shifts + 5 adds, no branches)

## Measured impact

Benchmarked via [sketch-bench](https://github.com/.../sketch-bench), 1M i64 inserts × 10 runs, single-threaded, pinned to one core, 10s CPU warmup:

| Sketch | Before | After | PGO baseline |
|---|---|---|---|
| `CountMin<QuickMatrixI32, FastPath>` 5×2048 | 89.7 M/s | **173.9 M/s** (+94%) | 179.2 M/s |
| `Count<QuickMatrixI32, FastPath>` 5×2048 | 71.5 M/s | **115.1 M/s** (+61%) | 119.3 M/s |

Both within 3% of PGO. Downstream sketch-bench no longer needs PGO machinery (or `-C llvm-args=-inline-threshold=...` overrides) to get the specialized fast path.

KLL and HLL throughput unchanged (don't traverse this hash chain).

## Asm verification

After the fix, in the bench's `run_cs_lib_fixedmatrix_fast` dispatch function:
- `hash_for_matrix_seeded_generic` is no longer a standalone symbol (fully inlined)
- Zero `call ...hash...` instructions in the inlined hot path
- Function body shrinks 70 KB → 54 KB (−23%, the dead `Rows`/`Packed128` arms got eliminated)
- The 5-row unrolled `Packed64` pattern (shifts at offsets 0/11/22/33/44, bases 0/0x2000/0x4000/0x6000/0x8000) dominates

## Test plan

- [x] `cargo test --features experimental` — 429+12+4+1+19 = 465 tests pass, 0 failures (5 pre-existing ignored)
- [x] Throughput sweep above
- [x] Disassembly inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)