### PR TITLE
Re-export MessagePackCodec at the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod __private {
 }
 
 pub use common::*;
+pub use message_pack_format::MessagePackCodec;
 pub use message_pack_format::portable::countminsketch::{CountMinSketch, CountMinSketchDelta};
 pub use message_pack_format::portable::countminsketch_topk::{CmsHeapItem, CountMinSketchWithHeap};
 pub use message_pack_format::portable::countsketch::{


### PR DESCRIPTION
## Summary
- Re-export the `MessagePackCodec` trait (`to_msgpack` / `from_msgpack`) at the crate root, alongside the portable sketch DTOs it operates on.
- Additive only: no existing signatures, wire format, or serialization behavior change.

This unblocks downstream consumers (`asap-precompute-rs`, ASAPQuery-backend `data_plane`) that call the portable sketch types' MessagePack serde methods without reaching into the `message_pack_format` submodule.

## Cross-repo dependency order
This PR must merge **first**. The downstream migrations depend on the crate-root `MessagePackCodec` export:
1. **asap_sketchlib** (this PR)
2. ASAPCollector `asap-precompute-rs` migration
3. ASAPQuery-backend `data_plane` migration

## Test plan
- [x] `cargo test` green (404 unit + suites, 0 failed)
- [x] `SKETCHLIB_GO_DIR=... cargo test --test xtest_consumer` — cross-language harness 9/9 sketches PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)