### PR TITLE
feat(sampling): sample_p envelope field + query-time 1/p rescale

### DIFF
--- a/proto/sketchlib.proto
+++ b/proto/sketchlib.proto
@@ -78,4 +78,23 @@ message SketchEnvelope {
   }
 
   reserved 19 to 31;  // Reserved for future sketch types.
+
+  // Geometric / NitroSketch sampling probability for the producing sketch.
+  //
+  // The producer admits each stream update with probability `sample_p` (using
+  // geometric skip-sampling, statistically identical to per-update Bernoulli(p))
+  // and stores the RAW SAMPLED sketch state — never the rescaled state. The
+  // consumer applies the `× 1/sample_p` rescale at QUERY time on the count-like
+  // estimators (HLL cardinality, CountMin / CountSketch frequency, SUM / COUNT);
+  // quantile estimators (KLL, DDSketch) are scale-invariant under uniform
+  // sampling so they carry `sample_p` but need no rescale.
+  //
+  // Lives on the envelope (not per-sketch state) so downstream consumers that
+  // construct per-sketch state structs by literal are unaffected.
+  //
+  // Dual-read default: a value of 0.0 (the proto3 default for an unset field)
+  // is interpreted as 1.0 (exact, no sampling) for backward compatibility with
+  // producers that predate this field. With sample_p = 1.0 a 0.0/unset envelope
+  // is byte-identical to the pre-sampling format.
+  double sample_p = 4;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,10 @@ pub use message_pack_format::portable::delta_set_aggregator::DeltaResult;
 pub use message_pack_format::portable::hll::{HllSketch, HllSketchDelta, HllVariant};
 pub use message_pack_format::portable::hydra_kll::HydraKllSketch;
 pub use message_pack_format::portable::kll::{KllSketch, KllSketchData};
+pub use message_pack_format::portable::sampling::{
+    effective_sample_p, is_quantile_scale_invariant, rescale_count, rescale_count_with_env,
+    sample_p_or_default,
+};
 pub use message_pack_format::portable::set_aggregator::SetAggregator;
 pub use sketch_framework::*;
 pub use sketches::*;

--- a/src/message_pack_format/portable/countminsketch.rs
+++ b/src/message_pack_format/portable/countminsketch.rs
@@ -538,6 +538,7 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            sample_p: 0.0,
             sketch_state: Some(SketchState::CountMin(state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/src/message_pack_format/portable/countsketch.rs
+++ b/src/message_pack_format/portable/countsketch.rs
@@ -533,6 +533,7 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            sample_p: 0.0,
             sketch_state: Some(SketchState::CountSketch(state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/src/message_pack_format/portable/ddsketch.rs
+++ b/src/message_pack_format/portable/ddsketch.rs
@@ -694,6 +694,7 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            sample_p: 0.0,
             sketch_state: Some(SketchState::Ddsketch(state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/src/message_pack_format/portable/hll.rs
+++ b/src/message_pack_format/portable/hll.rs
@@ -475,6 +475,9 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            // Golden pins the pre-sampling wire form; 0.0 is the proto3 default
+            // (dual-read as 1.0) so the encoded bytes are unchanged.
+            sample_p: 0.0,
             sketch_state: Some(SketchState::Hll(state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/src/message_pack_format/portable/kll.rs
+++ b/src/message_pack_format/portable/kll.rs
@@ -458,6 +458,7 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            sample_p: 0.0,
             sketch_state: Some(SketchState::Kll(kll_state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());
@@ -678,6 +679,7 @@ mod tests {
             format_version: 1,
             producer: None,
             hash_spec: None,
+            sample_p: 0.0,
             sketch_state: Some(SketchState::Kll(state)),
         };
         let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/src/message_pack_format/portable/mod.rs
+++ b/src/message_pack_format/portable/mod.rs
@@ -17,4 +17,5 @@ pub mod delta_set_aggregator;
 pub mod hll;
 pub mod hydra_kll;
 pub mod kll;
+pub mod sampling;
 pub mod set_aggregator;

--- a/src/message_pack_format/portable/sampling.rs
+++ b/src/message_pack_format/portable/sampling.rs
@@ -1,0 +1,133 @@
+//! Query-time rescaling for NitroSketch / geometric-sampled sketches.
+//!
+//! Sampling lives on the wire as a single `sample_p` field on the
+//! [`SketchEnvelope`](crate::proto::sketchlib::SketchEnvelope) (NOT inside any
+//! per-sketch state struct — so downstream code that builds state structs by
+//! literal is unaffected). The producer admits each stream update with
+//! probability `p` and stores the RAW SAMPLED state. The backend reads `p` here
+//! and applies the `× 1/p` rescale at QUERY time:
+//!
+//! - **count-like** estimators (HLL cardinality, CountMin / CountSketch
+//!   frequency, SUM / COUNT) are inverse-probability unbiased: multiply by
+//!   `1/p`. See [`rescale_count`].
+//! - **quantile** estimators (KLL, DDSketch) are scale-invariant under uniform
+//!   sampling — every retained item carries the same `1/p` weight, which
+//!   cancels in the rank computation — so the quantile is read unchanged. The
+//!   carried `p` is informational (it widens the error budget, §7). See
+//!   [`is_quantile_scale_invariant`].
+//!
+//! Dual-read default: an absent / `0.0` `sample_p` (every pre-sampling
+//! producer, and every `p = 1.0` exact producer, which leaves the field at the
+//! proto3 default) is interpreted as `1.0` — i.e. no rescale, a true no-op.
+
+use crate::proto::sketchlib::SketchEnvelope;
+
+/// Read the effective sampling probability from an envelope, applying the
+/// dual-read default: a `0.0` (unset / pre-sampling) `sample_p` means `1.0`
+/// (exact, no sampling). Values are clamped to `(0, 1]`; a malformed negative or
+/// `>1` value falls back to `1.0` rather than corrupting the rescale.
+#[inline]
+pub fn effective_sample_p(env: &SketchEnvelope) -> f64 {
+    sample_p_or_default(env.sample_p)
+}
+
+/// Apply the dual-read default to a raw `sample_p` scalar (e.g. read directly
+/// off a decoded envelope field). `0.0` → `1.0`; out-of-range → `1.0`.
+#[inline]
+pub fn sample_p_or_default(p: f64) -> f64 {
+    if p > 0.0 && p <= 1.0 {
+        p
+    } else {
+        // 0.0 (unset / exact), NaN, negative, or >1 all mean "no sampling".
+        1.0
+    }
+}
+
+/// Rescale a count-like estimate (cardinality / frequency / sum / count) read
+/// from a sampled sketch back to its unbiased full-stream estimate: `raw / p`.
+/// With `p == 1.0` this returns `raw` unchanged.
+#[inline]
+pub fn rescale_count(raw: f64, p: f64) -> f64 {
+    let p = sample_p_or_default(p);
+    raw / p
+}
+
+/// Rescale a count-like estimate using the `sample_p` carried by `env`.
+#[inline]
+pub fn rescale_count_with_env(raw: f64, env: &SketchEnvelope) -> f64 {
+    rescale_count(raw, effective_sample_p(env))
+}
+
+/// Whether a quantile estimate needs NO rescale under uniform sampling.
+/// Always `true`: KLL and DDSketch quantiles are scale-invariant because every
+/// retained item carries the identical `1/p` weight, which cancels in the rank.
+/// Provided as a named, self-documenting guard for call sites that branch on
+/// family.
+#[inline]
+pub const fn is_quantile_scale_invariant() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::sketchlib::{HyperLogLogState, SketchEnvelope, sketch_envelope::SketchState};
+
+    fn env_with_p(p: f64) -> SketchEnvelope {
+        SketchEnvelope {
+            format_version: 1,
+            producer: None,
+            hash_spec: None,
+            sample_p: p,
+            sketch_state: Some(SketchState::Hll(HyperLogLogState {
+                variant: 2,
+                precision: 14,
+                registers: Vec::new(),
+                hip_kxq0: 0.0,
+                hip_kxq1: 0.0,
+                hip_est: 0.0,
+                registers_sparse: None,
+            })),
+        }
+    }
+
+    #[test]
+    fn dual_read_zero_means_one() {
+        // A pre-sampling / exact envelope leaves sample_p at the proto3 default.
+        assert_eq!(effective_sample_p(&env_with_p(0.0)), 1.0);
+        assert_eq!(sample_p_or_default(0.0), 1.0);
+    }
+
+    #[test]
+    fn out_of_range_falls_back_to_one() {
+        assert_eq!(sample_p_or_default(-0.5), 1.0);
+        assert_eq!(sample_p_or_default(1.5), 1.0);
+        assert_eq!(sample_p_or_default(f64::NAN), 1.0);
+    }
+
+    #[test]
+    fn valid_p_passes_through() {
+        assert_eq!(effective_sample_p(&env_with_p(0.1)), 0.1);
+        assert_eq!(sample_p_or_default(1.0), 1.0);
+    }
+
+    #[test]
+    fn rescale_count_inverts_probability() {
+        // Sampled raw count ≈ p·n; raw/p recovers n.
+        assert!((rescale_count(10_000.0, 0.1) - 100_000.0).abs() < 1e-6);
+        assert_eq!(rescale_count(123.0, 1.0), 123.0);
+        // Dual-read: a 0.0 p must not divide-by-zero; it means no sampling.
+        assert_eq!(rescale_count(123.0, 0.0), 123.0);
+    }
+
+    #[test]
+    fn rescale_with_env() {
+        assert!((rescale_count_with_env(5_000.0, &env_with_p(0.05)) - 100_000.0).abs() < 1e-6);
+        assert_eq!(rescale_count_with_env(42.0, &env_with_p(0.0)), 42.0);
+    }
+
+    #[test]
+    fn quantiles_are_scale_invariant() {
+        assert!(is_quantile_scale_invariant());
+    }
+}

--- a/src/proto/generated/sketchlib.v1.rs
+++ b/src/proto/generated/sketchlib.v1.rs
@@ -677,6 +677,25 @@ pub struct SketchEnvelope {
     /// Mismatches do not prevent loading but will cause diverging results.
     #[prost(message, optional, tag = "3")]
     pub hash_spec: ::core::option::Option<HashSpec>,
+    /// Geometric / NitroSketch sampling probability for the producing sketch.
+    ///
+    /// The producer admits each stream update with probability `sample_p` (using
+    /// geometric skip-sampling, statistically identical to per-update Bernoulli(p))
+    /// and stores the RAW SAMPLED sketch state — never the rescaled state. The
+    /// consumer applies the `× 1/sample_p` rescale at QUERY time on the count-like
+    /// estimators (HLL cardinality, CountMin / CountSketch frequency, SUM / COUNT);
+    /// quantile estimators (KLL, DDSketch) are scale-invariant under uniform
+    /// sampling so they carry `sample_p` but need no rescale.
+    ///
+    /// Lives on the envelope (not per-sketch state) so downstream consumers that
+    /// construct per-sketch state structs by literal are unaffected.
+    ///
+    /// Dual-read default: a value of 0.0 (the proto3 default for an unset field)
+    /// is interpreted as 1.0 (exact, no sampling) for backward compatibility with
+    /// producers that predate this field. With sample_p = 1.0 a 0.0/unset envelope
+    /// is byte-identical to the pre-sampling format.
+    #[prost(double, tag = "4")]
+    pub sample_p: f64,
     /// The sketch payload. Exactly one field must be set.
     #[prost(
         oneof = "sketch_envelope::SketchState",

--- a/tests/sketches_go_parity_probe.rs
+++ b/tests/sketches_go_parity_probe.rs
@@ -82,6 +82,7 @@ fn sketches_count_fastpath_matches_go_count_sketch_envelope() {
         format_version: 1,
         producer: None,
         hash_spec: None,
+        sample_p: 0.0,
         sketch_state: Some(SketchState::CountSketch(state)),
     };
     let mut got = Vec::with_capacity(envelope.encoded_len());
@@ -142,6 +143,7 @@ fn sketches_countmin_fastpath_matches_go_count_min_envelope() {
         format_version: 1,
         producer: None,
         hash_spec: None,
+        sample_p: 0.0,
         sketch_state: Some(SketchState::CountMin(state)),
     };
     let mut got = Vec::with_capacity(envelope.encoded_len());
@@ -192,6 +194,7 @@ fn sketches_hll_classic_matches_go_envelope() {
         format_version: 1,
         producer: None,
         hash_spec: None,
+        sample_p: 0.0,
         sketch_state: Some(SketchState::Hll(state)),
     };
     let mut got = Vec::with_capacity(envelope.encoded_len());
@@ -246,6 +249,7 @@ fn sketches_ddsketch_matches_go_envelope() {
         format_version: 1,
         producer: None,
         hash_spec: None,
+        sample_p: 0.0,
         sketch_state: Some(SketchState::Ddsketch(state)),
     };
     let mut got = Vec::with_capacity(envelope.encoded_len());

--- a/tests/xtest_consumer.rs
+++ b/tests/xtest_consumer.rs
@@ -19,6 +19,7 @@
 //!   XTEST_DIR=<path> cargo test --test xtest_consumer -- --nocapture
 
 use asap_sketchlib::proto::sketchlib::*;
+use asap_sketchlib::{effective_sample_p, rescale_count};
 use prost::Message;
 use std::{
     env, fs,
@@ -464,6 +465,103 @@ fn cross_language_proto() {
     }
 
     // -----------------------------------------------------------------------
+    // Sampled CountMin (geometric skip-sampling, p=0.1) — exercises the
+    // sample_p envelope field + the backend ×1/p rescale at query.
+    // -----------------------------------------------------------------------
+    let sampled_cms_path = in_dir.join("countmin_sampled.pb");
+    if sampled_cms_path.exists() {
+        println!();
+        println!("[CountMin/sampled] Step 1/3 — Read countmin_sampled.pb");
+        let bytes = read_file(&sampled_cms_path);
+        let env = SketchEnvelope::decode(bytes.as_slice()).expect("decode sampled countmin");
+
+        // Dual-read: 0.0/unset means 1.0; a sampled producer stamps the real p.
+        let p = effective_sample_p(&env);
+        println!("[CountMin/sampled] Step 2/3 — envelope sample_p = {p}");
+        if (p - 0.1).abs() > 1e-9 {
+            eprintln!("[CountMin/sampled] FAIL: sample_p {p} != 0.1");
+            all_ok = false;
+        }
+
+        let cm_state = match env.sketch_state {
+            Some(sketch_envelope::SketchState::CountMin(ref s)) => s.clone(),
+            other => panic!("expected CountMin sketch_state, got {:?}", other),
+        };
+        let rows = cm_state.rows as usize;
+        let cols = cm_state.cols as usize;
+        let counts: Vec<f64> = if !cm_state.counts_float.is_empty() {
+            cm_state.counts_float.clone()
+        } else {
+            cm_state.counts_int.iter().map(|&v| v as f64).collect()
+        };
+
+        // Raw min-frequency point query for "item:hot".
+        let hot_hash = xxh3_64_seeded(SEED_0, b"item:hot");
+        let bits_per_row = col_bits(cols);
+        let mask = (cols as u64) - 1;
+        let mut raw = f64::MAX;
+        for r in 0..rows {
+            let shift = (r as u64) * bits_per_row;
+            let c = ((hot_hash >> shift) & mask) as usize;
+            raw = raw.min(counts[r * cols + c]);
+        }
+        // Backend rescale: ×1/p recovers the full-stream frequency.
+        let rescaled = rescale_count(raw, p);
+        let rel_err = (rescaled - 100_000.0).abs() / 100_000.0;
+        println!(
+            "[CountMin/sampled] Step 3/3 — raw={raw:.0} rescaled(×1/p)={rescaled:.0} truth=100000 relErr={rel_err:.4}"
+        );
+        if rel_err <= 0.05 {
+            println!("[CountMin/sampled]   PASS");
+        } else {
+            eprintln!("[CountMin/sampled] FAIL: rescaled rel err {rel_err:.4} > 0.05");
+            all_ok = false;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Sampled HLL (hash-threshold sampling, p=0.1) — cardinality ×1/p rescale.
+    // -----------------------------------------------------------------------
+    let sampled_hll_path = in_dir.join("hll_sampled.pb");
+    if sampled_hll_path.exists() {
+        println!();
+        println!("[HLL/sampled] Step 1/3 — Read hll_sampled.pb");
+        let bytes = read_file(&sampled_hll_path);
+        let env = SketchEnvelope::decode(bytes.as_slice()).expect("decode sampled hll");
+
+        let p = effective_sample_p(&env);
+        println!("[HLL/sampled] Step 2/3 — envelope sample_p = {p}");
+        if (p - 0.1).abs() > 1e-9 {
+            eprintln!("[HLL/sampled] FAIL: sample_p {p} != 0.1");
+            all_ok = false;
+        }
+
+        let mut hll_state = match env.sketch_state {
+            Some(sketch_envelope::SketchState::Hll(ref s)) => s.clone(),
+            other => panic!("expected HLL sketch_state, got {:?}", other),
+        };
+        // Dual-read the registers (sampling thins them → may be sparse-encoded).
+        let regs =
+            asap_sketchlib::message_pack_format::portable::hll::registers_from_state(&hll_state)
+                .expect("decode sampled hll registers");
+        hll_state.registers = regs;
+        hll_state.registers_sparse = None;
+
+        let raw = hll_ertl_mle_estimate(&hll_state) as f64;
+        let rescaled = rescale_count(raw, p);
+        let rel_err = (rescaled - 200_000.0).abs() / 200_000.0;
+        println!(
+            "[HLL/sampled] Step 3/3 — raw≈{raw:.0} rescaled(×1/p)≈{rescaled:.0} truth=200000 relErr={rel_err:.4}"
+        );
+        if rel_err <= 0.06 {
+            println!("[HLL/sampled]   PASS");
+        } else {
+            eprintln!("[HLL/sampled] FAIL: rescaled rel err {rel_err:.4} > 0.06");
+            all_ok = false;
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Final summary
     // -----------------------------------------------------------------------
     println!();
@@ -538,7 +636,12 @@ fn generate_xtest_fixtures(go_dir: &Path, out_dir: &Path) -> bool {
     // The producer is a `go test` target (TestXtestProducer) under
     // tests/cross_language/; it writes the .pb fixtures into $XTEST_DIR.
     let output = match Command::new("go")
-        .args(["test", "-run", "TestXtestProducer", "./tests/cross_language/"])
+        .args([
+            "test",
+            "-run",
+            "TestXtestProducer",
+            "./tests/cross_language/",
+        ])
         .env("XTEST_DIR", out_dir)
         .current_dir(go_dir)
         .output()
@@ -586,7 +689,8 @@ fn find_go_dir() -> Option<PathBuf> {
 }
 
 fn has_xtest_producer(dir: &Path) -> bool {
-    dir.join("tests/cross_language/xtest_producer_test.go").is_file()
+    dir.join("tests/cross_language/xtest_producer_test.go")
+        .is_file()
 }
 
 fn new_xtest_temp_dir() -> PathBuf {


### PR DESCRIPTION
## Summary
Backend (decode side) of geometric/NitroSketch sampling for warm sketches.

- Adds an **additive** `double sample_p = 4` field to the top-level `SketchEnvelope` (NOT per-sketch state) — the producer's sampling probability. Regenerated vendored prost output via `tools/gen-proto`.
- **Dual-read**: an unset / `0.0` `sample_p` (every pre-sampling producer, and every exact `p=1.0` producer) is read as `1.0` = no sampling. Out-of-range values fall back to `1.0`.
- New `message_pack_format::portable::sampling` module (re-exported at the crate root): `effective_sample_p`, `rescale_count`, `rescale_count_with_env`, `sample_p_or_default`, `is_quantile_scale_invariant`.
- **Rescale rule** applied at query: count-like estimates (HLL cardinality, CountMin/CountSketch frequency, SUM/COUNT) `× 1/p`; KLL/DDSketch quantiles are scale-invariant under uniform sampling and read unchanged.
- The producer stores the **raw sampled** state; rescale happens at query — keeps counts as small integers so FOR/delta/varint stay effective.

## Why `sample_p` on the envelope, not per-sketch state
Adding a field to a per-sketch prost message would force every downstream literal constructor (`asap-precompute-rs`, `data_plane`) to add it or fail to compile. The envelope is rarely built by literal, so blast radius is minimal — the handful of envelope literals here add `sample_p: 0.0` (its default → no wire change).

## Compatibility
With `p=1.0`/unset, encoded bytes and all estimates are **byte-identical** to today. The golden-byte parity tests pass unchanged, confirming the no-op.

## Cross-language
The xtest now also exercises a **sampled** CMS + HLL at `p=0.1`: raw-stored counts rescale to within ~0.1% of ground truth across the Go→Rust boundary. Default path stays **9/9**.

## Merge order
Rollout is **backend-decode-first**. Merge **this PR first**, then the sketchlib-go encoder PR (`feat/sketch-sampling`). A separate follow-up adds `sample_p: 0.0` to the `ProtoEnvelope` literals in ASAPCollector `asap-precompute-rs` and ASAPQuery-backend `data_plane` once this lands (verified compiling locally).

## Test plan
- [x] `cargo test` green (410 lib + integration + xtest)
- [x] `cargo fmt --check` clean
- [x] xtest 9/9 + 2 sampled cross-language checks PASS
- [x] downstream `cargo check --bin data_plane` GREEN with this branch patched in