### PR TITLE
docs: fix rustdoc redundant-explicit-link warning in sampling module

### DIFF
--- a/src/message_pack_format/portable/sampling.rs
+++ b/src/message_pack_format/portable/sampling.rs
@@ -1,7 +1,7 @@
 //! Query-time rescaling for NitroSketch / geometric-sampled sketches.
 //!
 //! Sampling lives on the wire as a single `sample_p` field on the
-//! [`SketchEnvelope`](crate::proto::sketchlib::SketchEnvelope) (NOT inside any
+//! [`SketchEnvelope`] (NOT inside any
 //! per-sketch state struct — so downstream code that builds state structs by
 //! literal is unaffected). The producer admits each stream update with
 //! probability `p` and stores the RAW SAMPLED state. The backend reads `p` here


### PR DESCRIPTION
## Summary
- The **Rust Docs** workflow (`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`) was failing on `main` while Rust CI stayed green — only doc generation broke.
- Root cause: the sampling module doc comment (introduced by the recent `feat(sampling): sample_p` merge) used an explicit intra-doc link target `[`SketchEnvelope`](crate::proto::sketchlib::SketchEnvelope)`. Since `SketchEnvelope` is already in scope via `use`, the bare label resolves to the same destination, tripping `rustdoc::redundant_explicit_links`, which `-D warnings` promotes to a hard error.
- Fix: drop the redundant explicit target in `src/message_pack_format/portable/sampling.rs`. The bare `[`SketchEnvelope`]` link still resolves correctly (verified in generated HTML).

This is a docs-only, one-line change — no public API or behavior change.

## Test plan
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked` (the exact Rust Docs command) passes clean
- [x] `cargo test --doc --all-features --locked` (19 doctests pass)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean
- [x] `cargo test --all-features --locked` (463 unit + integration + doctests all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)